### PR TITLE
Fix JUMPI inputs ordering

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
@@ -117,7 +117,7 @@ contract OVM_SafetyChecker is iOVM_SafetyChecker {
                         _pc += 8;
                     // Call EM and abort execution if instructed
                     // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x1d ADD EQ JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY PUSH1 0x00 REVERT JUMPDEST PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST
-                    } else if (firstOps == 0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b6001 && secondOps == 0x6000f35b) {
+                    } else if (firstOps == 0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b6001 && secondOps == 0x6000f35b) {
                         _pc += 36;
                     } else {
                         return false;

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
@@ -116,7 +116,7 @@ contract OVM_SafetyChecker is iOVM_SafetyChecker {
                     if ((firstOps >> 192) == 0x3350600060045af1) {
                         _pc += 8;
                     // Call EM and abort execution if instructed
-                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x1d ADD EQ JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY PUSH1 0x00 REVERT JUMPDEST PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST
+                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x1d ADD JUMPI RETURNDATASIZE PUSH1 0x01 EQ PC PUSH1 0x0c ADD JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x00 REVERT JUMPDEST PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST 
                     } else if (firstOps == 0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b6001 && secondOps == 0x6000f35b) {
                         _pc += 36;
                     } else {

--- a/test/data/json/safety-checker.test.json
+++ b/test/data/json/safety-checker.test.json
@@ -1073,7 +1073,7 @@
             "out": false
         },
         "valid EM call": {
-            "in": "0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b60016000f35b",
+            "in": "0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b60016000f35b",
             "out": true
         },
         "valid identity precompile call": {
@@ -1081,15 +1081,15 @@
             "out": true
         },
         "valid EM call, then valid identity precompile call": {
-            "in": "0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b60016000f35b3350600060045af1",
+            "in": "0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b60016000f35b3350600060045af1",
             "out": true
         },
         "valid EM call, then invalid identity precompile call": {
-            "in": "0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b60016000f35b3350600060035af1",
+            "in": "0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b60016000f35b3350600060035af1",
             "out": false
         },
         "valid EM call, then invalid opcode (SLOAD)": {
-            "in": "0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b60016000f35b54",
+            "in": "0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b60016000f35b54",
             "out": false
         },
         "valid identity precompile call, then invalid opcode (SLOAD)": {
@@ -1097,7 +1097,7 @@
             "out": false
         },
         "invalid EM call (missing final byte)": {
-            "in": "0x336000905af158601d0157586012013d600114573d6000803e3d6000fd5b60016000f3",
+            "in": "0x336000905af158601d01573d60011458600c01573d6000803e3d6000FD5b60016000f3",
             "out": false
         },
         "invalid identity precompile call (missing final byte)": {


### PR DESCRIPTION
Fixes a small bug in the safety checked logic where the input to `JUMPI` switched the `condition` and `destination`.