### PR TITLE
Remove unneed byte & remove .only

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -303,8 +303,11 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, OVM_Ba
 
                 assembly {
                     let chainElementStart := add(_chainElement, 0x20)
+                    // Set the first byte equal to `1` to indicate this is a sequencer chain element.
+                    // This distinguishes sequencer ChainElements from queue ChainElements because
+                    // all queue ChainElements are ABI encoded and the first byte of ABI encoded
+                    // elements is always zero
                     mstore8(chainElementStart, 1)
-                    mstore8(add(chainElementStart, 1), 0)
                     mstore(add(chainElementStart, 2), _timestamp)
                     mstore(add(chainElementStart, 34), _blockNumber)
                     // Store the rest of the transaction
@@ -655,7 +658,6 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, OVM_Ba
         assembly {
             let chainElementStart := add(_chainElement, 0x20)
             mstore8(chainElementStart, 1)
-            mstore8(add(chainElementStart, 1), 0)
             mstore(add(chainElementStart, 2), _timestamp)
             mstore(add(chainElementStart, 34), _blockNumber)
 

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -131,7 +131,7 @@ const encodeBatchContext = (context: BatchContext): string => {
   )
 }
 
-describe.only('OVM_CanonicalTransactionChain', () => {
+describe('OVM_CanonicalTransactionChain', () => {
   let signer: Signer
   let sequencer: Signer
   before(async () => {


### PR DESCRIPTION
## Description
Quick fix, removing an unused byte in the hashing of sequencer chain elements.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
