### PR TITLE
Allow easy emptying of the queue

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -14,6 +14,17 @@ import { iOVM_CanonicalTransactionChain } from "../../iOVM/chain/iOVM_CanonicalT
 /* Contract Imports */
 import { OVM_ExecutionManager } from "../execution/OVM_ExecutionManager.sol";
 
+
+library Math {
+    function min(uint x, uint y) internal pure returns (uint z) {
+        if (x < y) {
+            return x;
+        }
+        return y;
+    }
+}
+
+
 /**
  * @title OVM_CanonicalTransactionChain
  */
@@ -239,9 +250,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         uint40 nextQueueIndex = getNextQueueIndex();
         uint40 queueLength = _getQueueLength();
-        if (queueLength - nextQueueIndex < _numQueuedTransactions) {
-            _numQueuedTransactions = queueLength - nextQueueIndex;
-        }
+        _numQueuedTransactions = Math.min(_numQueuedTransactions, queueLength - nextQueueIndex);
         require(
             _numQueuedTransactions > 0,
             "Must append more than zero transactions."
@@ -538,7 +547,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             uint40
         )
     {
-        return queue.getLength()/2;
+        // The underlying queue data structure stores 2 elements
+        // per insertion, so to get the real queue length we need
+        // to divide by 2. See the usage of `push2(..)`.
+        return queue.getLength() / 2;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.3",
   "main": "build/src/index.js",
   "files": [
     "build/**/*.js",

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -423,7 +423,7 @@ describe('OVM_CanonicalTransactionChain', () => {
     it('should revert if the queue is empty', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(1)
-      ).to.be.revertedWith('Index out of bounds.')
+      ).to.be.revertedWith('No appendable queue elements.')
     })
 
     describe('when the queue is not empty', () => {
@@ -449,9 +449,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 OVM_CanonicalTransactionChain.connect(signer).appendQueueBatch(
                   1
                 )
-              ).to.be.revertedWith(
-                'Queue transactions cannot be submitted during the sequencer inclusion period.'
-              )
+              ).to.be.revertedWith('No appendable queue elements.')
             })
 
             it('should succeed if called by the sequencer', async () => {
@@ -485,10 +483,12 @@ describe('OVM_CanonicalTransactionChain', () => {
                 .withArgs(0, size, size)
             })
 
-            it(`should revert if appending ${size} + 1 elements`, async () => {
+            it(`should be able to append ${size} elements even if attempting to append ${size} + 1 elements`, async () => {
               await expect(
                 OVM_CanonicalTransactionChain.appendQueueBatch(size + 1)
-              ).to.be.revertedWith('Index out of bounds.')
+              )
+                .to.emit(OVM_CanonicalTransactionChain, 'QueueBatchAppended')
+                .withArgs(0, size, size)
             })
           })
         })

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -423,7 +423,9 @@ describe('OVM_CanonicalTransactionChain', () => {
     it('should revert if the queue is empty', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(1)
-      ).to.be.revertedWith('No appendable queue elements.')
+      ).to.be.revertedWith(
+        'Must append more than zero transactions.'
+      )
     })
 
     describe('when the queue is not empty', () => {
@@ -449,7 +451,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 OVM_CanonicalTransactionChain.connect(signer).appendQueueBatch(
                   1
                 )
-              ).to.be.revertedWith('No appendable queue elements.')
+              ).to.be.revertedWith('Queue transactions cannot be submitted during the sequencer inclusion period.')
             })
 
             it('should succeed if called by the sequencer', async () => {

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -423,9 +423,7 @@ describe('OVM_CanonicalTransactionChain', () => {
     it('should revert if the queue is empty', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(1)
-      ).to.be.revertedWith(
-        'Must append more than zero transactions.'
-      )
+      ).to.be.revertedWith('Must append more than zero transactions.')
     })
 
     describe('when the queue is not empty', () => {
@@ -451,7 +449,9 @@ describe('OVM_CanonicalTransactionChain', () => {
                 OVM_CanonicalTransactionChain.connect(signer).appendQueueBatch(
                   1
                 )
-              ).to.be.revertedWith('Queue transactions cannot be submitted during the sequencer inclusion period.')
+              ).to.be.revertedWith(
+                'Queue transactions cannot be submitted during the sequencer inclusion period.'
+              )
             })
 
             it('should succeed if called by the sequencer', async () => {


### PR DESCRIPTION
## Description
Fixes a slight race condition where if you attempt to empty the queue with a number of elements that is larger than the total number of elements in the queue, you will have your tx revert. Because of this we had a mild race condition where if two people append queue batches, one might fail.

Additionally there was some weird behavior where you couldn't verify an element unless it was passed the force inclusion period. This isn't fatal but increases client complexity.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
