### PR TITLE
deployment: register the sequencer address correctly

### DIFF
--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -61,7 +61,7 @@ export const makeContractDeployConfig = async (
           typeof sequencer === 'string'
             ? sequencer
             : await sequencer.getAddress()
-        await AddressManager.setAddress('Sequencer', sequencerAddress)
+        await AddressManager.setAddress('OVM_Sequencer', sequencerAddress)
       },
     },
     OVM_StateCommitmentChain: {


### PR DESCRIPTION
## Description

Sets the sequencer key to `OVM_Sequencer`

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
