### PR TITLE
remove msg.sender from all SafeEM calls

### DIFF
--- a/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -30,7 +30,6 @@ contract OVM_ProxyEOA {
         external
     {
         (bool success, bytes memory returndata) = Lib_SafeExecutionManagerWrapper.safeDELEGATECALL(
-            msg.sender,
             gasleft(),
             getImplementation(),
             msg.data
@@ -42,7 +41,6 @@ contract OVM_ProxyEOA {
             }
         } else {
             Lib_SafeExecutionManagerWrapper.safeREVERT(
-                msg.sender,
                 string(returndata)
             );
         }
@@ -59,8 +57,7 @@ contract OVM_ProxyEOA {
         external
     {
         Lib_SafeExecutionManagerWrapper.safeREQUIRE(
-            msg.sender,
-            Lib_SafeExecutionManagerWrapper.safeADDRESS(msg.sender) == Lib_SafeExecutionManagerWrapper.safeCALLER(msg.sender),
+            Lib_SafeExecutionManagerWrapper.safeADDRESS() == Lib_SafeExecutionManagerWrapper.safeCALLER(),
             "EOAs can only upgrade their own EOA implementation"
         );
 
@@ -75,7 +72,6 @@ contract OVM_ProxyEOA {
     {
         return address(uint160(uint256(
             Lib_SafeExecutionManagerWrapper.safeSLOAD(
-                msg.sender,
                 bytes32(uint256(0))
             )
         )));
@@ -91,7 +87,6 @@ contract OVM_ProxyEOA {
         internal
     {
         Lib_SafeExecutionManagerWrapper.safeSSTORE(
-            msg.sender,
             bytes32(uint256(0)),
             bytes32(uint256(uint160(_implementation)))
         );

--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_ProxySequencerEntrypoint.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_ProxySequencerEntrypoint.sol
@@ -16,7 +16,6 @@ contract OVM_ProxySequencerEntrypoint {
         external
     {
         Lib_SafeExecutionManagerWrapper.safeDELEGATECALL(
-            msg.sender,
             gasleft(),
             _getImplementation(),
             msg.data
@@ -35,7 +34,6 @@ contract OVM_ProxySequencerEntrypoint {
         external
     {
         Lib_SafeExecutionManagerWrapper.safeREQUIRE(
-            msg.sender,
             _getOwner() == address(0),
             "ProxySequencerEntrypoint has already been inited"
         );
@@ -49,8 +47,7 @@ contract OVM_ProxySequencerEntrypoint {
         external
     {
         Lib_SafeExecutionManagerWrapper.safeREQUIRE(
-            msg.sender,
-            _getOwner() == Lib_SafeExecutionManagerWrapper.safeCALLER(msg.sender),
+            _getOwner() == Lib_SafeExecutionManagerWrapper.safeCALLER(),
             "Only owner can upgrade the Entrypoint"
         );
 
@@ -68,7 +65,6 @@ contract OVM_ProxySequencerEntrypoint {
         internal
     {
         Lib_SafeExecutionManagerWrapper.safeSSTORE(
-            msg.sender,
             bytes32(uint256(0)),
             bytes32(uint256(uint160(_implementation)))
         );
@@ -82,7 +78,6 @@ contract OVM_ProxySequencerEntrypoint {
     {
         return address(uint160(uint256(
             Lib_SafeExecutionManagerWrapper.safeSLOAD(
-                msg.sender,
                 bytes32(uint256(0))
             )
         )));
@@ -94,7 +89,6 @@ contract OVM_ProxySequencerEntrypoint {
         internal
     {
         Lib_SafeExecutionManagerWrapper.safeSSTORE(
-            msg.sender,
             bytes32(uint256(1)),
             bytes32(uint256(uint160(_owner)))
         );
@@ -108,7 +102,6 @@ contract OVM_ProxySequencerEntrypoint {
     {
         return address(uint160(uint256(
             Lib_SafeExecutionManagerWrapper.safeSLOAD(
-                msg.sender,
                 bytes32(uint256(1))
             )
         )));

--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
@@ -63,10 +63,10 @@ contract OVM_SequencerEntrypoint {
             s
         );
 
-        if (Lib_SafeExecutionManagerWrapper.safeEXTCODESIZE(msg.sender, target) == 0) {
+        if (Lib_SafeExecutionManagerWrapper.safeEXTCODESIZE(target) == 0) {
             // ProxyEOA has not yet been deployed for this EOA.
             bytes32 messageHash = Lib_ECDSAUtils.getMessageHash(encodedTx, isEthSignedMessage);
-            Lib_SafeExecutionManagerWrapper.safeCREATEEOA(msg.sender, messageHash, uint8(v), r, s);
+            Lib_SafeExecutionManagerWrapper.safeCREATEEOA(messageHash, uint8(v), r, s);
         }
 
         // ProxyEOA has been deployed for this EOA, continue to CALL.
@@ -80,7 +80,6 @@ contract OVM_SequencerEntrypoint {
         );
 
         Lib_SafeExecutionManagerWrapper.safeCALL(
-            msg.sender,
             gasleft(),
             target,
             callbytes
@@ -111,7 +110,6 @@ contract OVM_SequencerEntrypoint {
             return TransactionType.ETH_SIGNED_MESSAGE;
         } else {
             Lib_SafeExecutionManagerWrapper.safeREVERT(
-                msg.sender,
                 "Transaction type must be 0 or 2"
             );
         }

--- a/contracts/optimistic-ethereum/libraries/wrappers/Lib_SafeExecutionManagerWrapper.sol
+++ b/contracts/optimistic-ethereum/libraries/wrappers/Lib_SafeExecutionManagerWrapper.sol
@@ -12,7 +12,6 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Makes an ovmCALL and performs all the necessary safety checks.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _gasLimit Gas limit for the call.
      * @param _target Address to call.
      * @param _calldata Data to send to the call.
@@ -20,7 +19,6 @@ library Lib_SafeExecutionManagerWrapper {
      * @return _returndata Data returned by the call.
      */
     function safeCALL(
-        address _ovmExecutionManager,
         uint256 _gasLimit,
         address _target,
         bytes memory _calldata
@@ -32,7 +30,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmCALL(uint256,address,bytes)",
                 _gasLimit,
@@ -46,7 +43,6 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Makes an ovmCALL and performs all the necessary safety checks.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _gasLimit Gas limit for the call.
      * @param _target Address to call.
      * @param _calldata Data to send to the call.
@@ -54,7 +50,6 @@ library Lib_SafeExecutionManagerWrapper {
      * @return _returndata Data returned by the call.
      */
     function safeDELEGATECALL(
-        address _ovmExecutionManager,
         uint256 _gasLimit,
         address _target,
         bytes memory _calldata
@@ -66,7 +61,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmDELEGATECALL(uint256,address,bytes)",
                 _gasLimit,
@@ -80,13 +74,11 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs an ovmCREATE and the necessary safety checks.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _gasLimit Gas limit for the creation.
      * @param _bytecode Code for the new contract.
      * @return _contract Address of the created contract.
      */
     function safeCREATE(
-        address _ovmExecutionManager,
         uint256 _gasLimit,
         bytes memory _bytecode
     )
@@ -96,7 +88,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             _gasLimit,
             abi.encodeWithSignature(
                 "ovmCREATE(bytes)",
@@ -109,12 +100,10 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs an ovmEXTCODESIZE and the necessary safety checks.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _contract Address of the contract to query the size of.
      * @return _EXTCODESIZE Size of the requested contract in bytes.
      */
     function safeEXTCODESIZE(
-        address _ovmExecutionManager,
         address _contract
     )
         internal
@@ -123,7 +112,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmEXTCODESIZE(address)",
                 _contract
@@ -135,19 +123,15 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmCHAINID call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @return _CHAINID Result of calling ovmCHAINID.
      */
-    function safeCHAINID(
-        address _ovmExecutionManager
-    )
+    function safeCHAINID()
         internal
         returns (
             uint256 _CHAINID
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmCHAINID()"
             )
@@ -158,19 +142,15 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmCALLER call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @return _CALLER Result of calling ovmCALLER.
      */
-    function safeCALLER(
-        address _ovmExecutionManager
-    )
+    function safeCALLER()
         internal
         returns (
             address _CALLER
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmCALLER()"
             )
@@ -181,19 +161,15 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmADDRESS call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @return _ADDRESS Result of calling ovmADDRESS.
      */
-    function safeADDRESS(
-        address _ovmExecutionManager
-    )
+    function safeADDRESS()
         internal
         returns (
             address _ADDRESS
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmADDRESS()"
             )
@@ -204,19 +180,15 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmGETNONCE call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @return _nonce Result of calling ovmGETNONCE.
      */
-    function safeGETNONCE(
-        address _ovmExecutionManager
-    )
+    function safeGETNONCE()
         internal
         returns (
             uint256 _nonce
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmGETNONCE()"
             )
@@ -227,17 +199,14 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmSETNONCE call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _nonce New account nonce.
      */
     function safeSETNONCE(
-        address _ovmExecutionManager,
         uint256 _nonce
     )
         internal
     {
         _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmSETNONCE(uint256)",
                 _nonce
@@ -247,14 +216,12 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe ovmCREATEEOA call.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _messageHash Message hash which was signed by EOA
      * @param _v v value of signature (0 or 1)
      * @param _r r value of signature
      * @param _s s value of signature
      */
     function safeCREATEEOA(
-        address _ovmExecutionManager,
         bytes32 _messageHash,
         uint8 _v,
         bytes32 _r,
@@ -263,7 +230,6 @@ library Lib_SafeExecutionManagerWrapper {
         internal
     {
         _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmCREATEEOA(bytes32,uint8,bytes32,bytes32)",
                 _messageHash,
@@ -276,17 +242,14 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe REVERT.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _reason String revert reason to pass along with the REVERT.
      */
     function safeREVERT(
-        address _ovmExecutionManager,
         string memory _reason
     )
         internal
     {
         _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmREVERT(bytes)",
                 bytes(_reason)
@@ -296,12 +259,10 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs a safe "require".
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _condition Boolean condition that must be true or will revert.
      * @param _reason String revert reason to pass along with the REVERT.
      */
     function safeREQUIRE(
-        address _ovmExecutionManager,
         bool _condition,
         string memory _reason
     )
@@ -309,7 +270,6 @@ library Lib_SafeExecutionManagerWrapper {
     {
         if (!_condition) {
             safeREVERT(
-                _ovmExecutionManager,
                 _reason
             );
         }
@@ -319,7 +279,6 @@ library Lib_SafeExecutionManagerWrapper {
      * Performs a safe ovmSLOAD call.
      */
     function safeSLOAD(
-        address _ovmExecutionManager,
         bytes32 _key
     )
         internal
@@ -328,7 +287,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         bytes memory returndata = _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmSLOAD(bytes32)",
                 _key
@@ -342,14 +300,12 @@ library Lib_SafeExecutionManagerWrapper {
      * Performs a safe ovmSSTORE call.
      */
     function safeSSTORE(
-        address _ovmExecutionManager,
         bytes32 _key,
         bytes32 _value
     )
         internal
     {
         _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             abi.encodeWithSignature(
                 "ovmSSTORE(bytes32,bytes32)",
                 _key,
@@ -364,13 +320,11 @@ library Lib_SafeExecutionManagerWrapper {
 
     /**
      * Performs an ovm interaction and the necessary safety checks.
-     * @param _ovmExecutionManager Address of the OVM_ExecutionManager.
      * @param _gasLimit Gas limit for the interaction.
      * @param _calldata Data to send to the OVM_ExecutionManager (encoded with sighash).
      * @return _returndata Data sent back by the OVM_ExecutionManager.
      */
     function _safeExecutionManagerInteraction(
-        address _ovmExecutionManager,
         uint256 _gasLimit,
         bytes memory _calldata
     )
@@ -379,10 +333,11 @@ library Lib_SafeExecutionManagerWrapper {
             bytes memory _returndata
         )
     {
+        address ovmExecutionManager = msg.sender;
         (
             bool success,
             bytes memory returndata
-        ) = _ovmExecutionManager.call{gas: _gasLimit}(_calldata);
+        ) = ovmExecutionManager.call{gas: _gasLimit}(_calldata);
 
         if (success == false) {
             assembly {
@@ -398,7 +353,6 @@ library Lib_SafeExecutionManagerWrapper {
     }
 
     function _safeExecutionManagerInteraction(
-        address _ovmExecutionManager,
         bytes memory _calldata
     )
         private
@@ -407,7 +361,6 @@ library Lib_SafeExecutionManagerWrapper {
         )
     {
         return _safeExecutionManagerInteraction(
-            _ovmExecutionManager,
             gasleft(),
             _calldata
         );

--- a/test/contracts/OVM/execution/OVM_ExecutionManager/ovmCREATEEOA.spec.ts
+++ b/test/contracts/OVM/execution/OVM_ExecutionManager/ovmCREATEEOA.spec.ts
@@ -65,7 +65,7 @@ const test_ovmCREATEEOA: TestDefinition = {
             address: '0x17ec8597ff92C3F44523bDc65BF0f1bE632917ff',
           },
           expectedReturnStatus: true,
-          expectedReturnValue: 1638,
+          expectedReturnValue: 1619,
         },
       ],
     },


### PR DESCRIPTION
## Description
This little PR removes the `_ovmExecutionManager` argument from `Lib_SafeExecutionManagerWrapper`, since the `evmCALLER` is the only acceptable parameter anyways.

## Questions
N/A

## Metadata
### Fixes
- small code readability downside

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
