### PR TITLE
ctc: forceInclusionPeriodSeconds + lastOVMTimestamp public

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -52,8 +52,8 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * Variables *
      *************/
 
-    uint256 internal forceInclusionPeriodSeconds;
-    uint256 internal lastOVMTimestamp;
+    uint256 public forceInclusionPeriodSeconds;
+    uint256 public lastOVMTimestamp;
     Lib_RingBuffer.RingBuffer internal batches;
     Lib_RingBuffer.RingBuffer internal queue;
 


### PR DESCRIPTION
## Description

Makes the `forceInclusionPeriodSeconds` and `lastOVMTimestamp` public, these are useful for the verifier

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
