### PR TITLE
Static Refunds for ovmCALL; ovmCREATE

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -78,9 +78,9 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      **********************/
 
     /**
-     * Applies a net gas cost refund to a transaction to account for the difference in execution
-     * between L1 and L2.
-     * @param _cost Gas cost for the function after the refund.
+     * Applies dynamically-sized refund to a transaction to account for the difference in execution
+     * between L1 and L2, so that the overall cost of the ovmOPCODE is fixed.
+     * @param _cost Desired gas cost for the function after the refund.
      */
     modifier netGasCost(
         uint256 _cost
@@ -92,6 +92,27 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         // We want to refund everything *except* the specified cost.
         if (_cost < gasUsed) {
             transactionRecord.ovmGasRefund += gasUsed - _cost;
+        }
+    }
+
+    /**
+     * Applies a fixed-size gas refund to a transaction to account for the difference in execution
+     * between L1 and L2, so that the overall cost of an ovmOPCODE can be lowered.
+     * @param _discount Amount of gas cost to refund for the ovmOPCODE.
+     */
+    modifier fixedGasDiscount(
+        uint256 _discount
+    ) {
+        uint256 gasProvided = gasleft();
+        _;
+        uint256 gasUsed = gasProvided - gasleft();
+
+        // We want to refund the specified _discount, unless this risks underflow.
+        if (_discount < gasUsed) {
+            transactionRecord.ovmGasRefund += _discount;
+        } else {
+            // refund all we can without risking underflow.
+            transactionRecord.ovmGasRefund += gasUsed;
         }
     }
 
@@ -327,7 +348,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         notStatic
-        netGasCost(40000 + _bytecode.length * 100)
+        fixedGasDiscount(40000)
         returns (
             address _contract
         )
@@ -360,7 +381,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         notStatic
-        netGasCost(40000 + _bytecode.length * 100)
+        fixedGasDiscount(40000)
         returns (
             address _contract
         )
@@ -503,7 +524,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         override
         public
-        netGasCost(100000)
+        fixedGasDiscount(100000)
         returns (
             bool _success,
             bytes memory _returndata
@@ -539,7 +560,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         override
         public
-        netGasCost(80000)
+        fixedGasDiscount(80000)
         returns (
             bool _success,
             bytes memory _returndata
@@ -576,7 +597,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         override
         public
-        netGasCost(40000)
+        fixedGasDiscount(40000)
         returns (
             bool _success,
             bytes memory _returndata


### PR DESCRIPTION
## Description
This PR tackles OZ H06 (roadmap # 189).  TLDR: `ovmCALL` and `ovmCREATE` should get statically sized refunds, not dynamic refunds resulting in a static overall cost, since their subsequent gas consumption is itself quite dynamic.

## Questions
- Not sure the best way to unit test this fix though it should definitely work.  Probably a generic gas refund test ticket to be broken out there.  @kfichter LMK if you have any ideas for robust testing of both of the modifiers.

## Metadata
### Fixes
- Fixes roadmap # 189

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
