### PR TITLE
Fix RLPWriter Memory Allocation

### DIFF
--- a/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPWriter.sol
+++ b/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPWriter.sol
@@ -89,7 +89,7 @@ library Lib_RLPWriter {
             bytes memory _out
         )
     {
-        _malloc(1);
+        _malloc(0x20);
         bytes memory inputBytes;
         assembly {
             let m := mload(0x40)
@@ -310,16 +310,19 @@ library Lib_RLPWriter {
         return flattened;
     }
 
+    /**
+     * Clears memory wherever the free memory is pointing.
+     * @param _numBytes Number of bytes to clear out (will be rounded up to nearest word).
+     */
     function _malloc(
-        uint _numWords
+        uint _numBytes
     )
-        internal
+        private
         pure
     {
-        uint numBytes = 0x20 * _numWords;
         assembly {
             let free_mem := mload(0x40)
-            for { let offset := 0x00 } lt(offset, numBytes) { offset := add(offset, 0x20) } {
+            for { let offset := 0x00 } lt(offset, _numBytes) { offset := add(offset, 0x20) } {
                 mstore(add(free_mem, offset), 0x00)
             }
         }

--- a/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPWriter.sol
+++ b/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPWriter.sol
@@ -89,6 +89,7 @@ library Lib_RLPWriter {
             bytes memory _out
         )
     {
+        _malloc(1);
         bytes memory inputBytes;
         assembly {
             let m := mload(0x40)
@@ -307,5 +308,20 @@ library Lib_RLPWriter {
         }
 
         return flattened;
+    }
+
+    function _malloc(
+        uint _numWords
+    )
+        internal
+        pure
+    {
+        uint numBytes = 0x20 * _numWords;
+        assembly {
+            let free_mem := mload(0x40)
+            for { let offset := 0x00 } lt(offset, numBytes) { offset := add(offset, 0x20) } {
+                mstore(add(free_mem, offset), 0x00)
+            }
+        }
     }
 }

--- a/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
+++ b/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_RLPWriter } from "../../optimistic-ethereum/libraries/rlp/Lib_RLPWriter.sol";
+import { TestERC20 } from "../../test-helpers/TestERC20.sol";
 
 /**
  * @title TestLib_RLPWriter
@@ -92,5 +93,17 @@ contract TestLib_RLPWriter {
         )
     {
         return Lib_RLPWriter.writeBool(_in);
+    }
+
+    function writeAddressWithOtherMemory(
+        address _in
+    )
+        public
+        returns (
+            bytes memory _out
+        )
+    {
+        new TestERC20();
+        return Lib_RLPWriter.writeAddress(_in);
     }
 }

--- a/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
+++ b/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
@@ -41,4 +41,13 @@ describe('Lib_RLPWriter', () => {
       })
     }
   })
+
+  describe.only('Use of library with other memory-modifying operations', () => {
+    it('should allow creation of a contract beforehand and still work', async () => {
+      const randomAddress = '0x1234123412341234123412341234123412341234'
+      const rlpEncodedRandomAddress = '0xd5941234123412341234123412341234123412341234'
+      const encoded = await Lib_RLPWriter.callStatic.writeAddressWithOtherMemory(randomAddress)
+      expect(encoded).to.eq(rlpEncodedRandomAddress)
+    })
+  })
 })

--- a/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
+++ b/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
@@ -45,7 +45,7 @@ describe('Lib_RLPWriter', () => {
   describe.only('Use of library with other memory-modifying operations', () => {
     it('should allow creation of a contract beforehand and still work', async () => {
       const randomAddress = '0x1234123412341234123412341234123412341234'
-      const rlpEncodedRandomAddress = '0xd5941234123412341234123412341234123412341234'
+      const rlpEncodedRandomAddress = '0x941234123412341234123412341234123412341234'
       const encoded = await Lib_RLPWriter.callStatic.writeAddressWithOtherMemory(randomAddress)
       expect(encoded).to.eq(rlpEncodedRandomAddress)
     })


### PR DESCRIPTION
## Description
Adds a `_malloc` function for clearing memory at the free pointer, and adds a test which would fail for `writeAddress` without it.

## Questions
Which functions need this applied? All of them?

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
