### PR TITLE
Added mock bond manager to deploy config

### DIFF
--- a/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
+++ b/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+/* Interface Imports */
+import { iOVM_BondManager } from "../../iOVM/verification/iOVM_BondManager.sol";
+
+/**
+ * @title mockOVM_BondManager
+ */
+contract mockOVM_BondManager is iOVM_BondManager {
+    function recordGasSpent(
+        bytes32 _preStateRoot,
+        address _who,
+        uint256 _gasSpent
+    )
+        override
+        public
+    {}
+
+    function finalize(
+        bytes32 _preStateRoot,
+        address _publisher,
+        uint256 _timestamp
+    )
+        override
+        public
+    {}
+
+    function deposit()
+        override
+        public
+    {}
+
+    function startWithdrawal()
+        override
+        public
+    {}
+
+    function finalizeWithdrawal()
+        override
+        public
+    {}
+
+    function claim(
+        bytes32 _preStateRoot
+    )
+        override
+        public
+    {}
+
+    function isCollateralized(
+        address _who
+    )
+        override
+        public
+        view
+        returns (
+            bool
+        )
+    {
+        return true;
+    }
+
+    function getGasSpent(
+        bytes32 _preStateRoot,
+        address _who
+    )
+        override
+        public
+        view
+        returns (
+            uint256
+        )
+    {
+        return 0;
+    }
+}

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -155,5 +155,8 @@ export const makeContractDeployConfig = async (
     mockOVM_ECDSAContractAccount: {
       factory: getContractFactory('mockOVM_ECDSAContractAccount'),
     },
+    OVM_BondManager: {
+      factory: getContractFactory('mockOVM_BondManager'),
+    },
   }
 }


### PR DESCRIPTION
## Description
Very simple PR, adds a `mockOVM_BondManager` to the deploy config as a temporary way to test the `OVM_StateCommitmentChain` without having to manually deploy a real `OVM_BondManager`.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
