### PR TITLE
Patches StateTransitioner to fix RLP-encoded storage slot values

### DIFF
--- a/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -7,6 +7,8 @@ import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 import { Lib_EthUtils } from "../../libraries/utils/Lib_EthUtils.sol";
 import { Lib_SecureMerkleTrie } from "../../libraries/trie/Lib_SecureMerkleTrie.sol";
+import { Lib_RLPWriter } from "../../libraries/rlp/Lib_RLPWriter.sol";
+import { Lib_RLPReader } from "../../libraries/rlp/Lib_RLPReader.sol";
 
 /* Interface Imports */
 import { iOVM_StateTransitioner } from "../../iOVM/verification/iOVM_StateTransitioner.sol";
@@ -266,12 +268,14 @@ contract OVM_StateTransitioner is Lib_AddressResolver, OVM_FraudContributor, iOV
 
         (
             bool exists,
-            bytes memory value
+            bytes memory encodedValue
         ) = Lib_SecureMerkleTrie.get(
             abi.encodePacked(_key),
             _storageTrieWitness,
             ovmStateManager.getAccountStorageRoot(_ovmContractAddress)
         );
+
+        bytes memory value = Lib_RLPReader.readBytes(encodedValue);
 
         if (exists == true) {
             require(
@@ -393,7 +397,9 @@ contract OVM_StateTransitioner is Lib_AddressResolver, OVM_FraudContributor, iOV
 
         account.storageRoot = Lib_SecureMerkleTrie.update(
             abi.encodePacked(_key),
-            abi.encodePacked(value),
+            Lib_RLPWriter.writeBytes(
+                abi.encodePacked(value)
+            ),
             _storageTrieWitness,
             account.storageRoot
         );

--- a/test/bond.ts
+++ b/test/bond.ts
@@ -302,11 +302,7 @@ describe('BondManager', () => {
 
         // a dispute is created about a block that intersects
         const disputeTimestamp = withdrawalTimestamp - 100
-        await fraudVerifier.finalize(
-          preStateRoot,
-          sender,
-          disputeTimestamp
-        )
+        await fraudVerifier.finalize(preStateRoot, sender, disputeTimestamp)
 
         await mineBlock(deployer.provider, timestamp)
         await expect(bondManager.finalizeWithdrawal()).to.be.revertedWith(
@@ -321,11 +317,7 @@ describe('BondManager', () => {
         // a dispute is created, but since the fraud period is already over
         // it doesn't matter
         const disputeTimestamp = withdrawalTimestamp - ONE_WEEK - 1
-        await fraudVerifier.finalize(
-          preStateRoot,
-          sender,
-          disputeTimestamp
-        )
+        await fraudVerifier.finalize(preStateRoot, sender, disputeTimestamp)
 
         const finalizeWithdrawalTimestamp = withdrawalTimestamp + ONE_WEEK
         await mineBlock(deployer.provider, finalizeWithdrawalTimestamp)

--- a/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -214,7 +214,7 @@ describe('OVM_ECDSAContractAccount', () => {
     it(`should revert on incorrect chainId`, async () => {
       const alteredChainIdTx = {
         ...DEFAULT_EIP155_TX,
-        chainId : 421
+        chainId: 421,
       }
       const message = serializeNativeTransaction(alteredChainIdTx)
       const sig = await signNativeTransaction(wallet, alteredChainIdTx)

--- a/test/contracts/OVM/execution/OVM_StateManager.gas-spec.ts
+++ b/test/contracts/OVM/execution/OVM_StateManager.gas-spec.ts
@@ -6,7 +6,15 @@ import { Contract, ContractFactory, Signer, BigNumber } from 'ethers'
 import _ from 'lodash'
 
 /* Internal Imports */
-import { DUMMY_ACCOUNTS, DUMMY_BYTES32, ZERO_ADDRESS, EMPTY_ACCOUNT_CODE_HASH, NON_ZERO_ADDRESS, NON_NULL_BYTES32, STORAGE_XOR_VALUE } from '../../../helpers'
+import {
+  DUMMY_ACCOUNTS,
+  DUMMY_BYTES32,
+  ZERO_ADDRESS,
+  EMPTY_ACCOUNT_CODE_HASH,
+  NON_ZERO_ADDRESS,
+  NON_NULL_BYTES32,
+  STORAGE_XOR_VALUE,
+} from '../../../helpers'
 
 const DUMMY_ACCOUNT = DUMMY_ACCOUNTS[0]
 const DUMMY_KEY = DUMMY_BYTES32[0]
@@ -14,514 +22,428 @@ const DUMMY_VALUE_1 = DUMMY_BYTES32[1]
 const DUMMY_VALUE_2 = DUMMY_BYTES32[2]
 
 describe('OVM_StateManager gas consumption', () => {
-    let owner: Signer
-    before(async () => {
-      ;[owner] = await ethers.getSigners()
-    })
-  
-    let Factory__OVM_StateManager: ContractFactory
-    let Helper_GasMeasurer: Contract
-    before(async () => {
-      Factory__OVM_StateManager = await ethers.getContractFactory(
-        'OVM_StateManager'
-      )
+  let owner: Signer
+  before(async () => {
+    ;[owner] = await ethers.getSigners()
+  })
 
-      Helper_GasMeasurer = await (await (await ethers.getContractFactory(
-        'Helper_GasMeasurer'
-      )).deploy()).connect(owner)
-    })
+  let Factory__OVM_StateManager: ContractFactory
+  let Helper_GasMeasurer: Contract
+  before(async () => {
+    Factory__OVM_StateManager = await ethers.getContractFactory(
+      'OVM_StateManager'
+    )
 
-    let OVM_StateManager: Contract
-    beforeEach(async () => {
-        OVM_StateManager = (
-        await Factory__OVM_StateManager.deploy(await owner.getAddress())
-        ).connect(owner)
+    Helper_GasMeasurer = await (
+      await (await ethers.getContractFactory('Helper_GasMeasurer')).deploy()
+    ).connect(owner)
+  })
 
-        await OVM_StateManager.setExecutionManager(Helper_GasMeasurer.address)
-    })
+  let OVM_StateManager: Contract
+  beforeEach(async () => {
+    OVM_StateManager = (
+      await Factory__OVM_StateManager.deploy(await owner.getAddress())
+    ).connect(owner)
 
-    const measure = (
-        methodName: string, 
-        methodArgs: Array<any> = [],
-        doFirst: () => Promise<any> = async () => {return}
-    ) => {
-        it('measured consumption!', async () => {
-            await doFirst()
-            await getSMGasCost(methodName, methodArgs)
-        })
+    await OVM_StateManager.setExecutionManager(Helper_GasMeasurer.address)
+  })
+
+  const measure = (
+    methodName: string,
+    methodArgs: Array<any> = [],
+    doFirst: () => Promise<any> = async () => {
+      return
     }
+  ) => {
+    it('measured consumption!', async () => {
+      await doFirst()
+      await getSMGasCost(methodName, methodArgs)
+    })
+  }
 
-    const getSMGasCost = async (methodName: string, methodArgs: Array<any> = []): Promise<number> => {
-        const gasCost: number = await Helper_GasMeasurer.callStatic.measureCallGas(
-            OVM_StateManager.address,
-            OVM_StateManager.interface.encodeFunctionData(
-                methodName,
-                methodArgs
+  const getSMGasCost = async (
+    methodName: string,
+    methodArgs: Array<any> = []
+  ): Promise<number> => {
+    const gasCost: number = await Helper_GasMeasurer.callStatic.measureCallGas(
+      OVM_StateManager.address,
+      OVM_StateManager.interface.encodeFunctionData(methodName, methodArgs)
+    )
+    console.log(`          calculated gas cost of ${gasCost}`)
+
+    return gasCost
+  }
+
+  const setupFreshAccount = async () => {
+    await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+      ...DUMMY_ACCOUNT.data,
+      isFresh: true,
+    })
+  }
+  const setupNonFreshAccount = async () => {
+    await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, DUMMY_ACCOUNT.data)
+  }
+  const putSlot = async (value: string) => {
+    await OVM_StateManager.putContractStorage(
+      DUMMY_ACCOUNT.address,
+      DUMMY_KEY,
+      value
+    )
+  }
+
+  describe('ItemState testAndSetters', () => {
+    describe('testAndSetAccountLoaded', () => {
+      describe('when account ItemState is ITEM_UNTOUCHED', () => {
+        measure('testAndSetAccountLoaded', [NON_ZERO_ADDRESS])
+      })
+      describe('when account ItemState is ITEM_LOADED', () => {
+        measure('testAndSetAccountLoaded', [NON_ZERO_ADDRESS], async () => {
+          await OVM_StateManager.testAndSetAccountLoaded(NON_ZERO_ADDRESS)
+        })
+      })
+      describe('when account ItemState is ITEM_CHANGED', () => {
+        measure('testAndSetAccountLoaded', [NON_ZERO_ADDRESS], async () => {
+          await OVM_StateManager.testAndSetAccountChanged(NON_ZERO_ADDRESS)
+        })
+      })
+    })
+
+    describe('testAndSetAccountChanged', () => {
+      describe('when account ItemState is ITEM_UNTOUCHED', () => {
+        measure('testAndSetAccountChanged', [NON_ZERO_ADDRESS])
+      })
+      describe('when account ItemState is ITEM_LOADED', () => {
+        measure('testAndSetAccountChanged', [NON_ZERO_ADDRESS], async () => {
+          await OVM_StateManager.testAndSetAccountLoaded(NON_ZERO_ADDRESS)
+        })
+      })
+      describe('when account ItemState is ITEM_CHANGED', () => {
+        measure('testAndSetAccountChanged', [NON_ZERO_ADDRESS], async () => {
+          await OVM_StateManager.testAndSetAccountChanged(NON_ZERO_ADDRESS)
+        })
+      })
+    })
+
+    describe('testAndSetContractStorageLoaded', () => {
+      describe('when storage ItemState is ITEM_UNTOUCHED', () => {
+        measure('testAndSetContractStorageLoaded', [
+          NON_ZERO_ADDRESS,
+          DUMMY_KEY,
+        ])
+      })
+      describe('when storage ItemState is ITEM_LOADED', () => {
+        measure(
+          'testAndSetContractStorageLoaded',
+          [NON_ZERO_ADDRESS, DUMMY_KEY],
+          async () => {
+            await OVM_StateManager.testAndSetContractStorageLoaded(
+              NON_ZERO_ADDRESS,
+              DUMMY_KEY
             )
+          }
         )
-        console.log(`          calculated gas cost of ${gasCost}`)
+      })
+      describe('when storage ItemState is ITEM_CHANGED', () => {
+        measure(
+          'testAndSetContractStorageLoaded',
+          [NON_ZERO_ADDRESS, DUMMY_KEY],
+          async () => {
+            await OVM_StateManager.testAndSetContractStorageChanged(
+              NON_ZERO_ADDRESS,
+              DUMMY_KEY
+            )
+          }
+        )
+      })
+    })
 
-        return gasCost
-    }
+    describe('testAndSetContractStorageChanged', () => {
+      describe('when storage ItemState is ITEM_UNTOUCHED', () => {
+        measure('testAndSetContractStorageChanged', [
+          NON_ZERO_ADDRESS,
+          DUMMY_KEY,
+        ])
+      })
+      describe('when storage ItemState is ITEM_LOADED', () => {
+        measure(
+          'testAndSetContractStorageChanged',
+          [NON_ZERO_ADDRESS, DUMMY_KEY],
+          async () => {
+            await OVM_StateManager.testAndSetContractStorageLoaded(
+              NON_ZERO_ADDRESS,
+              DUMMY_KEY
+            )
+          }
+        )
+      })
+      describe('when storage ItemState is ITEM_CHANGED', () => {
+        measure(
+          'testAndSetContractStorageChanged',
+          [NON_ZERO_ADDRESS, DUMMY_KEY],
+          async () => {
+            await OVM_StateManager.testAndSetContractStorageChanged(
+              NON_ZERO_ADDRESS,
+              DUMMY_KEY
+            )
+          }
+        )
+      })
+    })
+  })
 
-    const setupFreshAccount = async () => {
-        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
-            ...DUMMY_ACCOUNT.data,
-            isFresh: true,
-        })
-    }
-    const setupNonFreshAccount = async () => {
+  describe('incrementTotalUncommittedAccounts', () => {
+    describe('when totalUncommittedAccounts is 0', () => {
+      measure('incrementTotalUncommittedAccounts')
+    })
+    describe('when totalUncommittedAccounts is nonzero', () => {
+      const doFirst = async () => {
+        await OVM_StateManager.incrementTotalUncommittedAccounts()
+      }
+      measure('incrementTotalUncommittedAccounts', [], doFirst)
+    })
+  })
+
+  describe('incrementTotalUncommittedContractStorage', () => {
+    describe('when totalUncommittedContractStorage is 0', () => {
+      measure('incrementTotalUncommittedContractStorage')
+    })
+    describe('when totalUncommittedContractStorage is nonzero', () => {
+      const doFirst = async () => {
+        await OVM_StateManager.incrementTotalUncommittedContractStorage()
+      }
+      measure('incrementTotalUncommittedContractStorage', [], doFirst)
+    })
+  })
+
+  describe('hasAccount', () => {
+    describe('when it does have the account', () => {
+      const doFirst = async () => {
         await OVM_StateManager.putAccount(
-            DUMMY_ACCOUNT.address, 
-            DUMMY_ACCOUNT.data
+          DUMMY_ACCOUNT.address,
+          DUMMY_ACCOUNT.data
         )
+      }
+      measure('hasAccount', [DUMMY_ACCOUNT.address], doFirst)
+    })
+  })
+
+  describe('hasEmptyAccount', () => {
+    describe('when it does have an empty account', () => {
+      measure('hasEmptyAccount', [DUMMY_ACCOUNT.address], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          codeHash: EMPTY_ACCOUNT_CODE_HASH,
+        })
+      })
+    })
+    describe('when it has an account which is not emtpy', () => {
+      measure('hasEmptyAccount', [DUMMY_ACCOUNT.address], async () => {
+        await OVM_StateManager.putAccount(
+          DUMMY_ACCOUNT.address,
+          DUMMY_ACCOUNT.data
+        )
+      })
+    })
+  })
+
+  describe('setAccountNonce', () => {
+    describe('when the nonce is 0 and set to 0', () => {
+      measure('setAccountNonce', [DUMMY_ACCOUNT.address, 0], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          nonce: 0,
+        })
+      })
+    })
+    describe('when the nonce is 0 and set to nonzero', () => {
+      measure('setAccountNonce', [DUMMY_ACCOUNT.address, 1], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          nonce: 0,
+        })
+      })
+    })
+    describe('when the nonce is nonzero and set to 0', () => {
+      measure('setAccountNonce', [DUMMY_ACCOUNT.address, 0], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          nonce: 1,
+        })
+      })
+    })
+    describe('when the nonce is nonzero and set to nonzero', () => {
+      measure('setAccountNonce', [DUMMY_ACCOUNT.address, 2], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          nonce: 1,
+        })
+      })
+    })
+  })
+
+  describe('getAccountNonce', () => {
+    describe('when the nonce is 0', () => {
+      measure('getAccountNonce', [DUMMY_ACCOUNT.address])
+    })
+    describe('when the nonce is nonzero', () => {
+      measure('getAccountNonce', [DUMMY_ACCOUNT.address], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          nonce: 1,
+        })
+      })
+    })
+  })
+
+  describe('getAccountEthAddress', () => {
+    describe('when the ethAddress is a random address', () => {
+      measure('getAccountEthAddress', [DUMMY_ACCOUNT.address], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          ethAddress: NON_ZERO_ADDRESS,
+        })
+      })
+    })
+    describe('when the ethAddress is zero', () => {
+      measure('getAccountEthAddress', [DUMMY_ACCOUNT.address], async () => {
+        await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
+          ...DUMMY_ACCOUNT.data,
+          ethAddress: ZERO_ADDRESS,
+        })
+      })
+    })
+  })
+
+  describe('initPendingAccount', () => {
+    // note: this method should only be accessibl if _hasEmptyAccount is true, so it should always be empty nonce etc
+    measure('initPendingAccount', [NON_ZERO_ADDRESS])
+  })
+
+  describe('commitPendingAccount', () => {
+    // this should only set ethAddress and codeHash from ZERO to NONZERO, so one case should be sufficient
+    measure(
+      'commitPendingAccount',
+      [NON_ZERO_ADDRESS, NON_ZERO_ADDRESS, NON_NULL_BYTES32],
+      async () => {
+        await OVM_StateManager.initPendingAccount(NON_ZERO_ADDRESS)
+      }
+    )
+  })
+
+  describe('getContractStorage', () => {
+    // confirm with kelvin that this covers all cases
+    describe('when the account isFresh', () => {
+      describe('when the storage slot value has not been set', () => {
+        measure(
+          'getContractStorage',
+          [DUMMY_ACCOUNT.address, DUMMY_KEY],
+          setupFreshAccount
+        )
+      })
+      describe('when the storage slot has already been set', () => {
+        describe('when the storage slot value is STORAGE_XOR_VALUE', () => {
+          measure(
+            'getContractStorage',
+            [DUMMY_ACCOUNT.address, DUMMY_KEY],
+            async () => {
+              await setupFreshAccount()
+              await putSlot(STORAGE_XOR_VALUE)
+            }
+          )
+        })
+        describe('when the storage slot value is something other than STORAGE_XOR_VALUE', () => {
+          measure(
+            'getContractStorage',
+            [DUMMY_ACCOUNT.address, DUMMY_KEY],
+            async () => {
+              await setupFreshAccount()
+              await putSlot(DUMMY_VALUE_1)
+            }
+          )
+        })
+      })
+    })
+    describe('when the account is not fresh', () => {
+      describe('when the storage slot value is STORAGE_XOR_VALUE', () => {
+        measure(
+          'getContractStorage',
+          [DUMMY_ACCOUNT.address, DUMMY_KEY],
+          async () => {
+            await setupNonFreshAccount()
+            await putSlot(STORAGE_XOR_VALUE)
+          }
+        )
+      })
+      describe('when the storage slot value is something other than STORAGE_XOR_VALUE', () => {
+        measure(
+          'getContractStorage',
+          [DUMMY_ACCOUNT.address, DUMMY_KEY],
+          async () => {
+            await setupNonFreshAccount()
+            await putSlot(DUMMY_VALUE_1)
+          }
+        )
+      })
+    })
+  })
+
+  describe('putContractStorage', () => {
+    const relevantValues = [DUMMY_VALUE_1, DUMMY_VALUE_2, STORAGE_XOR_VALUE]
+    for (let preValue of relevantValues) {
+      for (let postValue of relevantValues) {
+        describe(`when overwriting ${preValue} with ${postValue}`, () => {
+          measure(
+            'putContractStorage',
+            [NON_ZERO_ADDRESS, DUMMY_KEY, postValue],
+            async () => {
+              await OVM_StateManager.putContractStorage(
+                NON_ZERO_ADDRESS,
+                DUMMY_KEY,
+                preValue
+              )
+            }
+          )
+        })
+      }
     }
-    const putSlot = async (value: string) => {
-        await OVM_StateManager.putContractStorage(
+  })
+
+  describe('hasContractStorage', () => {
+    describe('when the account is fresh', () => {
+      describe('when the storage slot has not been set', () => {
+        measure(
+          'hasContractStorage',
+          [DUMMY_ACCOUNT.address, DUMMY_KEY],
+          setupFreshAccount
+        )
+      })
+      describe('when the slot has already been set', () => {
+        measure(
+          'hasContractStorage',
+          [DUMMY_ACCOUNT.address, DUMMY_KEY],
+          async () => {
+            await setupFreshAccount()
+            await OVM_StateManager.putContractStorage(
+              DUMMY_ACCOUNT.address,
+              DUMMY_KEY,
+              DUMMY_VALUE_1
+            )
+          }
+        )
+      })
+    })
+    describe('when the account is not fresh', () => {
+      measure(
+        'hasContractStorage',
+        [DUMMY_ACCOUNT.address, DUMMY_KEY],
+        async () => {
+          await OVM_StateManager.putContractStorage(
             DUMMY_ACCOUNT.address,
             DUMMY_KEY,
-            value
-        )
-    }
-
-    describe('ItemState testAndSetters', () => {
-        describe('testAndSetAccountLoaded', () => {
-            describe('when account ItemState is ITEM_UNTOUCHED', () => {
-                measure(
-                    'testAndSetAccountLoaded',
-                    [NON_ZERO_ADDRESS]
-                )
-            })
-            describe('when account ItemState is ITEM_LOADED', () => {
-                measure(
-                    'testAndSetAccountLoaded',
-                    [NON_ZERO_ADDRESS],
-                    async () => {
-                        await OVM_StateManager.testAndSetAccountLoaded(NON_ZERO_ADDRESS)
-                    }
-                )
-            })
-            describe('when account ItemState is ITEM_CHANGED', () => {
-                measure(
-                    'testAndSetAccountLoaded',
-                    [NON_ZERO_ADDRESS],
-                    async () => {
-                        await OVM_StateManager.testAndSetAccountChanged(NON_ZERO_ADDRESS)
-                    }
-                )
-            })
-        })
-    
-        describe('testAndSetAccountChanged', () => {
-            describe('when account ItemState is ITEM_UNTOUCHED', () => {
-                measure(
-                    'testAndSetAccountChanged',
-                    [NON_ZERO_ADDRESS]
-                )
-            })
-            describe('when account ItemState is ITEM_LOADED', () => {
-                measure(
-                    'testAndSetAccountChanged',
-                    [NON_ZERO_ADDRESS],
-                    async () => {
-                        await OVM_StateManager.testAndSetAccountLoaded(NON_ZERO_ADDRESS)
-                    }
-                )
-            })
-            describe('when account ItemState is ITEM_CHANGED', () => {
-                measure(
-                    'testAndSetAccountChanged',
-                    [NON_ZERO_ADDRESS],
-                    async () => {
-                        await OVM_StateManager.testAndSetAccountChanged(NON_ZERO_ADDRESS)
-                    }
-                )
-            })
-        })
-
-        describe('testAndSetContractStorageLoaded', () => {
-            describe('when storage ItemState is ITEM_UNTOUCHED', () => {
-                measure(
-                    'testAndSetContractStorageLoaded',
-                    [NON_ZERO_ADDRESS, DUMMY_KEY]
-                )
-            })
-            describe('when storage ItemState is ITEM_LOADED', () => {
-                measure(
-                    'testAndSetContractStorageLoaded',
-                    [NON_ZERO_ADDRESS,  DUMMY_KEY],
-                    async () => {
-                        await OVM_StateManager.testAndSetContractStorageLoaded(NON_ZERO_ADDRESS,  DUMMY_KEY)
-                    }
-                )
-            })
-            describe('when storage ItemState is ITEM_CHANGED', () => {
-                measure(
-                    'testAndSetContractStorageLoaded',
-                    [NON_ZERO_ADDRESS,  DUMMY_KEY],
-                    async () => {
-                        await OVM_StateManager.testAndSetContractStorageChanged(NON_ZERO_ADDRESS,  DUMMY_KEY)
-                    }
-                )
-            })
-        })
-    
-        describe('testAndSetContractStorageChanged', () => {
-            describe('when storage ItemState is ITEM_UNTOUCHED', () => {
-                measure(
-                    'testAndSetContractStorageChanged',
-                    [NON_ZERO_ADDRESS, DUMMY_KEY]
-                )
-            })
-            describe('when storage ItemState is ITEM_LOADED', () => {
-                measure(
-                    'testAndSetContractStorageChanged',
-                    [NON_ZERO_ADDRESS,  DUMMY_KEY],
-                    async () => {
-                        await OVM_StateManager.testAndSetContractStorageLoaded(NON_ZERO_ADDRESS,  DUMMY_KEY)
-                    }
-                )
-            })
-            describe('when storage ItemState is ITEM_CHANGED', () => {
-                measure(
-                    'testAndSetContractStorageChanged',
-                    [NON_ZERO_ADDRESS,  DUMMY_KEY],
-                    async () => {
-                        await OVM_StateManager.testAndSetContractStorageChanged(NON_ZERO_ADDRESS,  DUMMY_KEY)
-                    }
-                )
-            })
-        })
-    })
-
-    describe('incrementTotalUncommittedAccounts', () => {
-        describe('when totalUncommittedAccounts is 0', () => {
-            measure('incrementTotalUncommittedAccounts')
-        })
-        describe('when totalUncommittedAccounts is nonzero', () => {
-            const doFirst = async () => {
-                await OVM_StateManager.incrementTotalUncommittedAccounts()
-            }
-            measure('incrementTotalUncommittedAccounts', [], doFirst)
-        })
-    })
-    
-    describe('incrementTotalUncommittedContractStorage', () => {
-        describe('when totalUncommittedContractStorage is 0', () => {
-            measure('incrementTotalUncommittedContractStorage')
-        })
-        describe('when totalUncommittedContractStorage is nonzero', () => {
-            const doFirst = async () => {
-                await OVM_StateManager.incrementTotalUncommittedContractStorage()
-            }
-            measure('incrementTotalUncommittedContractStorage', [], doFirst)
-        })
-    })
-
-    describe('hasAccount', () => {
-        describe('when it does have the account', () => {
-            const doFirst = async () => {
-                await OVM_StateManager.putAccount(
-                  DUMMY_ACCOUNT.address,
-                  DUMMY_ACCOUNT.data
-                )
-            }
-            measure(
-                'hasAccount',
-                [DUMMY_ACCOUNT.address],
-                doFirst
-            )
-        })
-    })
-
-    describe('hasEmptyAccount', () => {
-        describe('when it does have an empty account', () => {
-            measure(
-                'hasEmptyAccount',
-                [DUMMY_ACCOUNT.address],
-                async () => {
-                    await OVM_StateManager.putAccount(DUMMY_ACCOUNT.address, {
-                        ...DUMMY_ACCOUNT.data,
-                        codeHash: EMPTY_ACCOUNT_CODE_HASH,
-                    })
-                }
-            )
-        })
-        describe('when it has an account which is not emtpy', () => {
-            measure(
-                'hasEmptyAccount',
-                [DUMMY_ACCOUNT.address],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        DUMMY_ACCOUNT.data
-                    )
-                }
-            )
-        })
-    })
-
-    describe('setAccountNonce', () => {
-        describe('when the nonce is 0 and set to 0', () => {
-            measure(
-                'setAccountNonce',
-                [DUMMY_ACCOUNT.address, 0],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            nonce: 0
-                        }
-                    )
-                }
-            )
-        })
-        describe('when the nonce is 0 and set to nonzero', () => {
-            measure(
-                'setAccountNonce',
-                [DUMMY_ACCOUNT.address, 1],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            nonce: 0
-                        }
-                    )
-                }
-            )
-        })
-        describe('when the nonce is nonzero and set to 0', () => {
-            measure(
-                'setAccountNonce',
-                [DUMMY_ACCOUNT.address, 0],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            nonce: 1
-                        }
-                    )
-                }
-            )
-        })
-        describe('when the nonce is nonzero and set to nonzero', () => {
-            measure(
-                'setAccountNonce',
-                [DUMMY_ACCOUNT.address, 2],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            nonce: 1
-                        }
-                    )
-                }
-            )
-        })
-    })
-
-    describe('getAccountNonce', () => {
-        describe('when the nonce is 0', () => {
-            measure(
-                'getAccountNonce',
-                [DUMMY_ACCOUNT.address]
-            )
-        })
-        describe('when the nonce is nonzero', () => {
-            measure(
-                'getAccountNonce',
-                [DUMMY_ACCOUNT.address],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            nonce: 1
-                        }
-                    )
-                }
-            )
-        })
-    })
-
-    describe('getAccountEthAddress', () => {
-        describe('when the ethAddress is a random address', () => {
-            measure(
-                'getAccountEthAddress',
-                [DUMMY_ACCOUNT.address],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            ethAddress: NON_ZERO_ADDRESS
-                        }
-                    )
-                }
-            )
-        })
-        describe('when the ethAddress is zero', () => {
-            measure(
-                'getAccountEthAddress',
-                [DUMMY_ACCOUNT.address],
-                async () => {
-                    await OVM_StateManager.putAccount(
-                        DUMMY_ACCOUNT.address,
-                        {
-                            ...DUMMY_ACCOUNT.data,
-                            ethAddress: ZERO_ADDRESS
-                        }
-                    )
-                }
-            )
-        })
-    })
-    
-    describe('initPendingAccount', () => {
-        // note: this method should only be accessibl if _hasEmptyAccount is true, so it should always be empty nonce etc
-        measure(
-            'initPendingAccount',
-            [NON_ZERO_ADDRESS]
-        )
-    })
-
-    describe('commitPendingAccount', () => {
-        // this should only set ethAddress and codeHash from ZERO to NONZERO, so one case should be sufficient
-        measure(
-            'commitPendingAccount',
-            [
-                NON_ZERO_ADDRESS,
-                NON_ZERO_ADDRESS,
-                NON_NULL_BYTES32
-            ],
-            async () => {
-                await OVM_StateManager.initPendingAccount(NON_ZERO_ADDRESS)
-            }
-        )
-    })
-
-    describe('getContractStorage', () => {
-        // confirm with kelvin that this covers all cases
-        describe('when the account isFresh', () => {
-            describe('when the storage slot value has not been set', () => {
-                measure(
-                    'getContractStorage',
-                    [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                    setupFreshAccount
-                )
-            })
-            describe('when the storage slot has already been set', () => {
-                describe('when the storage slot value is STORAGE_XOR_VALUE', () => {
-                    measure(
-                        'getContractStorage',
-                        [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                        async () => {
-                            await setupFreshAccount()
-                            await putSlot(STORAGE_XOR_VALUE)
-                        }
-                    )
-                })
-                describe('when the storage slot value is something other than STORAGE_XOR_VALUE', () => {
-                    measure(
-                        'getContractStorage',
-                        [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                        async () => {
-                            await setupFreshAccount()
-                            await putSlot(DUMMY_VALUE_1)
-                        }
-                    )
-                })
-            })
-        })
-        describe('when the account is not fresh', () => {
-            describe('when the storage slot value is STORAGE_XOR_VALUE', () => {
-                measure(
-                    'getContractStorage',
-                    [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                    async () => {
-                        await setupNonFreshAccount()
-                        await putSlot(STORAGE_XOR_VALUE)
-                    }
-                )
-            })
-            describe('when the storage slot value is something other than STORAGE_XOR_VALUE', () => {
-                measure(
-                    'getContractStorage',
-                    [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                    async () => {
-                        await setupNonFreshAccount()
-                        await putSlot(DUMMY_VALUE_1)
-                    }
-                )
-            })
-        })          
-    })
-
-    describe('putContractStorage', () => {
-        const relevantValues = [
-            DUMMY_VALUE_1,
-            DUMMY_VALUE_2,
-            STORAGE_XOR_VALUE
-        ]
-        for (let preValue of relevantValues) {
-            for (let postValue of relevantValues) {
-                describe(`when overwriting ${preValue} with ${postValue}`, () => {
-                    measure(
-                        'putContractStorage',
-                        [NON_ZERO_ADDRESS, DUMMY_KEY, postValue],
-                        async () => {
-                            await OVM_StateManager.putContractStorage(
-                                NON_ZERO_ADDRESS,
-                                DUMMY_KEY,
-                                preValue
-                            )
-                        }
-                    )
-                })
-            }
+            DUMMY_VALUE_1
+          )
         }
+      )
     })
-
-    describe('hasContractStorage', () => {
-        describe('when the account is fresh', () => {
-            describe('when the storage slot has not been set', () => {
-                measure(
-                    'hasContractStorage',
-                    [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                    setupFreshAccount
-                )
-            })
-            describe('when the slot has already been set', () => {
-                measure(
-                    'hasContractStorage',
-                    [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                    async () => {
-                        await setupFreshAccount()
-                        await OVM_StateManager.putContractStorage(
-                            DUMMY_ACCOUNT.address,
-                            DUMMY_KEY,
-                            DUMMY_VALUE_1
-                        )
-                    }
-                )
-            })
-        })
-        describe('when the account is not fresh', () => {
-            measure(
-                'hasContractStorage',
-                [DUMMY_ACCOUNT.address, DUMMY_KEY],
-                async () => {
-                    await OVM_StateManager.putContractStorage(
-                        DUMMY_ACCOUNT.address,
-                        DUMMY_KEY,
-                        DUMMY_VALUE_1
-                    )
-                }
-            )
-        })
-    })
+  })
 })

--- a/test/contracts/OVM/execution/OVM_StateManager.spec.ts
+++ b/test/contracts/OVM/execution/OVM_StateManager.spec.ts
@@ -6,9 +6,13 @@ import { Contract, ContractFactory, Signer, BigNumber } from 'ethers'
 import _ from 'lodash'
 
 /* Internal Imports */
-import { DUMMY_ACCOUNTS, DUMMY_BYTES32, ZERO_ADDRESS, EMPTY_ACCOUNT_CODE_HASH, KECCAK_256_NULL } from '../../../helpers'
-
-
+import {
+  DUMMY_ACCOUNTS,
+  DUMMY_BYTES32,
+  ZERO_ADDRESS,
+  EMPTY_ACCOUNT_CODE_HASH,
+  KECCAK_256_NULL,
+} from '../../../helpers'
 
 describe('OVM_StateManager', () => {
   let signer1: Signer

--- a/test/contracts/OVM/verification/OVM_FraudVerifier.spec.ts
+++ b/test/contracts/OVM/verification/OVM_FraudVerifier.spec.ts
@@ -192,7 +192,7 @@ describe('OVM_FraudVerifier', () => {
         })
 
         it('should revert when provided with a incorrect transaction root global index', async () => {
-          await expect (
+          await expect(
             OVM_FraudVerifier.initializeFraudVerification(
               NULL_BYTES32,
               DUMMY_BATCH_HEADERS[0],
@@ -202,7 +202,9 @@ describe('OVM_FraudVerifier', () => {
               DUMMY_BATCH_HEADERS[0],
               DUMMY_BATCH_PROOFS_WITH_INDEX[0]
             )
-          ).to.be.revertedWith('Pre-state root global index must equal to the transaction root global index.')
+          ).to.be.revertedWith(
+            'Pre-state root global index must equal to the transaction root global index.'
+          )
         })
       })
     })

--- a/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
+++ b/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
@@ -4,6 +4,7 @@ import { expect } from '../../../setup'
 /* External Imports */
 import { ethers } from '@nomiclabs/buidler'
 import { BigNumber, Contract, ContractFactory } from 'ethers'
+import * as rlp from 'rlp'
 
 /* Internal Imports */
 import {
@@ -234,7 +235,7 @@ describe('OVM_StateTransitioner', () => {
             nodes: [
               {
                 key,
-                val,
+                val: '0x' + rlp.encode(val).toString('hex'),
               },
             ],
             secure: true,
@@ -268,7 +269,7 @@ describe('OVM_StateTransitioner', () => {
             nodes: [
               {
                 key,
-                val,
+                val: '0x' + rlp.encode(val).toString('hex'),
               },
             ],
             secure: true,
@@ -452,7 +453,7 @@ describe('OVM_StateTransitioner', () => {
             nodes: [
               {
                 key,
-                val,
+                val: '0x' + rlp.encode(val).toString('hex'),
               },
             ],
             secure: true,
@@ -460,7 +461,7 @@ describe('OVM_StateTransitioner', () => {
 
           const storageTest = await storageGenerator.makeNodeUpdateTest(
             key,
-            newVal
+            '0x' + rlp.encode(newVal).toString('hex')
           )
 
           const generator = await TrieTestGenerator.fromAccounts({


### PR DESCRIPTION
## Description
Storage slot values are RLP-encoded before being inserted into the state trie. Our StateTransitioner currently does not account for this. Patch fixes this by RLP-decoding the values we get out and RLP-encoding them when we update.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
