### PR TITLE
Hotfix for decoding rlp values in state transitioner

### DIFF
--- a/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -275,9 +275,8 @@ contract OVM_StateTransitioner is Lib_AddressResolver, OVM_FraudContributor, iOV
             ovmStateManager.getAccountStorageRoot(_ovmContractAddress)
         );
 
-        bytes memory value = Lib_RLPReader.readBytes(encodedValue);
-
         if (exists == true) {
+            bytes memory value = Lib_RLPReader.readBytes(encodedValue);
             require(
                 keccak256(value) == keccak256(abi.encodePacked(_value)),
                 "Provided storage slot value is invalid."


### PR DESCRIPTION
## Description
Last PR was in error, `StateTransitioner` should only be decoding RLP values if the value actually existed.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
