### PR TITLE
Move ganache-core to main deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/hardware-wallets": "^5.0.8",
     "@openzeppelin/contracts": "^3.3.0",
-    "ethers": "5.0.0"
+    "ethers": "5.0.0",
+    "ganache-core": "^2.12.1"
   },
   "devDependencies": {
     "@eth-optimism/smock": "^0.0.2",
@@ -49,7 +50,6 @@
     "copyfiles": "^2.3.0",
     "ethereum-waffle": "3.0.0",
     "fs-extra": "^9.0.1",
-    "ganache-core": "^2.12.1",
     "lodash": "^4.17.20",
     "merkle-patricia-tree": "^4.0.0",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
## Description
Moves `ganache-core` to `dependencies` instead of `devDependencies`. Fixes #95.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
