### PR TITLE
Fix rlp encoding bug in contract dump

### DIFF
--- a/src/contract-dumps.ts
+++ b/src/contract-dumps.ts
@@ -44,8 +44,9 @@ const getStorageDump = async (
       const stream = trie.createReadStream()
 
       stream.on('data', (val: any) => {
+        const storageSlotValue = ethers.utils.RLP.decode('0x' + val.value.toString('hex'))
         storage['0x' + val.key.toString('hex')] =
-          '0x' + val.value.toString('hex').slice(2)
+          storageSlotValue
       })
 
       stream.on('end', () => {

--- a/src/contract-dumps.ts
+++ b/src/contract-dumps.ts
@@ -44,9 +44,10 @@ const getStorageDump = async (
       const stream = trie.createReadStream()
 
       stream.on('data', (val: any) => {
-        const storageSlotValue = ethers.utils.RLP.decode('0x' + val.value.toString('hex'))
-        storage['0x' + val.key.toString('hex')] =
-          storageSlotValue
+        const storageSlotValue = ethers.utils.RLP.decode(
+          '0x' + val.value.toString('hex')
+        )
+        storage['0x' + val.key.toString('hex')] = storageSlotValue
       })
 
       stream.on('end', () => {


### PR DESCRIPTION
## Description
Instead of RLP decoding values from the storage trie, we were just slicing off the first byte. This works for most values, but values between `0x00` and 0x7f` are not prefixed when rlp encoding, so these values were getting wiped. 
## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
