### PR TITLE
Remove chainId check from mock account

### DIFF
--- a/contracts/optimistic-ethereum/mockOVM/accounts/mockOVM_ECDSAContractAccount.sol
+++ b/contracts/optimistic-ethereum/mockOVM/accounts/mockOVM_ECDSAContractAccount.sol
@@ -46,12 +46,6 @@ contract mockOVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
         bool isEthSign = _signatureType == Lib_OVMCodec.EOASignatureType.ETH_SIGNED_MESSAGE;
         Lib_OVMCodec.EIP155Transaction memory decodedTx = Lib_OVMCodec.decodeEIP155Transaction(_transaction, isEthSign);
 
-        // Need to make sure that the transaction chainId is correct.
-        Lib_SafeExecutionManagerWrapper.safeREQUIRE(
-            decodedTx.chainId == Lib_SafeExecutionManagerWrapper.safeCHAINID(),
-            "Transaction chainId does not match expected OVM chainId."
-        );
-
         // Need to make sure that the transaction nonce is right.
         Lib_SafeExecutionManagerWrapper.safeREQUIRE(
             decodedTx.nonce == Lib_SafeExecutionManagerWrapper.safeGETNONCE(),


### PR DESCRIPTION
## Description
Small PR to revert the chain ID assertion in our mock contract account.  Since this is used for things like `eth_call`, there's no need to authenticate.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
