### PR TITLE
Add OVM_L2Relayer Check to L1CrossDomainMessenger

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
@@ -45,6 +45,25 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCros
     }
 
 
+    /**********************
+     * Function Modifiers *
+     **********************/
+
+    /**
+     * Modifier to enforce that, if configured, only the OVM_L2MessageRelayer contract may successfully call a method.
+     */
+    modifier onlyRelayer() {
+        address relayer = resolve("OVM_L2MessageRelayer");
+        if (relayer != address(0)) {
+            require(
+                msg.sender == relayer,
+                "Only OVM_L2MessageRelayer can relay L2-to-L1 messages."
+            );
+        }
+        _;
+    }
+
+
     /********************
      * Public Functions *
      ********************/
@@ -62,6 +81,7 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCros
     )
         override
         public
+        onlyRelayer()
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
             _target,

--- a/test/contracts/OVM/bridge/OVM_L1CrossDomainMessenger.spec.ts
+++ b/test/contracts/OVM/bridge/OVM_L1CrossDomainMessenger.spec.ts
@@ -352,5 +352,23 @@ describe('OVM_L1CrossDomainMessenger', () => {
         )
       ).to.be.revertedWith('Provided message has already been received.')
     })
+
+    it('when the OVM_L2MessageRelayer address is set, should revert if called by a different account', async () => {
+      // set to a random NON-ZERO address
+      await AddressManager.setAddress(
+        'OVM_L2MessageRelayer',
+        '0x1234123412341234123412341234123412341234'
+      )
+
+      await expect(
+        OVM_L1CrossDomainMessenger.relayMessage(
+          target,
+          sender,
+          message,
+          0,
+          proof
+        )
+      ).to.be.revertedWith('Only OVM_L2MessageRelayer can relay L2-to-L1 messages.')
+    })
   })
 })


### PR DESCRIPTION
## Description
This PR adds a check in the `OVM_L1CrossDomainMessenger` to look up an `OVM_L2Relayer` address in the `AddressManager`.  If the address has been set, only the `OVM_L2Relayer` may call `OVM_L1CrossDomainMessenger.relayMessage()`.
## Metadata
### Fixes
- Fixes https://github.com/ethereum-optimism/roadmap/issues/160

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
