### PR TITLE
Add StateBatchDeleted event to SCC

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
@@ -450,6 +450,11 @@ contract OVM_StateCommitmentChain is iOVM_StateCommitmentChain, iRingBufferOverw
                 0
             )
         );
+
+        emit StateBatchDeleted(
+            _batchHeader.batchIndex,
+            _batchHeader.batchRoot
+        );
     }
 
     /**

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
@@ -22,6 +22,11 @@ interface iOVM_StateCommitmentChain {
         bytes _extraData
     );
 
+    event StateBatchDeleted(
+        uint256 indexed _batchIndex,
+        bytes32 _batchRoot
+    );
+
     /********************
      * Public Functions *
      ********************/


### PR DESCRIPTION
## Description
Adds a simple `StateBatchDeleted` event so we can filter out state batches that have been deleted (for use within the fraud prover).

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
