### PR TITLE
Update mockOVM_BondManager to be sequencer-only

### DIFF
--- a/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
+++ b/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
@@ -4,10 +4,19 @@ pragma solidity ^0.7.0;
 /* Interface Imports */
 import { iOVM_BondManager } from "../../iOVM/verification/iOVM_BondManager.sol";
 
+/* Contract Imports */
+import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
+
 /**
  * @title mockOVM_BondManager
  */
-contract mockOVM_BondManager is iOVM_BondManager {
+contract mockOVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
+    constructor(
+        address _libAddressManager
+    )
+        Lib_AddressResolver(_libAddressManager)
+    {}
+
     function recordGasSpent(
         bytes32 _preStateRoot,
         bytes32 _txHash,
@@ -59,7 +68,8 @@ contract mockOVM_BondManager is iOVM_BondManager {
             bool
         )
     {
-        return true;
+        // Only authenticate sequencer to submit state root batches.
+        return _who == resolve("OVM_Sequencer");
     }
 
     function getGasSpent(

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -164,6 +164,7 @@ export const makeContractDeployConfig = async (
     },
     OVM_BondManager: {
       factory: getContractFactory('mockOVM_BondManager'),
+      params: [AddressManager.address]
     },
     OVM_ETH: {
       factory: getContractFactory('OVM_ETH'),

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -164,7 +164,7 @@ export const makeContractDeployConfig = async (
     },
     OVM_BondManager: {
       factory: getContractFactory('mockOVM_BondManager'),
-      params: [AddressManager.address]
+      params: [AddressManager.address],
     },
     OVM_ETH: {
       factory: getContractFactory('OVM_ETH'),

--- a/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
+++ b/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
@@ -5,16 +5,14 @@ import { ethers } from '@nomiclabs/buidler'
 import { Signer, Contract } from 'ethers'
 
 /* Internal Imports */
-import {
-  makeAddressManager,
-} from '../../../helpers'
+import { makeAddressManager } from '../../../helpers'
 
 describe('mockOVM_BondManager', () => {
-    let sequencer: Signer
-    let nonSequencer: Signer
-    before(async () => {
-        ;[sequencer, nonSequencer] = await ethers.getSigners()
-    })
+  let sequencer: Signer
+  let nonSequencer: Signer
+  before(async () => {
+    ;[sequencer, nonSequencer] = await ethers.getSigners()
+  })
 
   let AddressManager: Contract
   before(async () => {
@@ -25,27 +23,24 @@ describe('mockOVM_BondManager', () => {
   before(async () => {
     mockOVM_BondManager = await (
       await ethers.getContractFactory('mockOVM_BondManager')
-    ).deploy(
-        AddressManager.address
-    )
-   
-    AddressManager.setAddress(
-        'OVM_Sequencer',
-        await sequencer.getAddress()
-    )
+    ).deploy(AddressManager.address)
+
+    AddressManager.setAddress('OVM_Sequencer', await sequencer.getAddress())
   })
 
   describe('isCollateralized', () => {
-      it('should return true for OVM_Sequencer', async () => {
-          expect(
-              await mockOVM_BondManager.isCollateralized(await sequencer.getAddress())
-          ).to.equal(true)
-      })
+    it('should return true for OVM_Sequencer', async () => {
+      expect(
+        await mockOVM_BondManager.isCollateralized(await sequencer.getAddress())
+      ).to.equal(true)
+    })
 
-      it('should return false for non-sequencer', async () => {
-        expect(
-            await mockOVM_BondManager.isCollateralized(await nonSequencer.getAddress())
-        ).to.equal(false)
-      })
+    it('should return false for non-sequencer', async () => {
+      expect(
+        await mockOVM_BondManager.isCollateralized(
+          await nonSequencer.getAddress()
+        )
+      ).to.equal(false)
+    })
   })
 })

--- a/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
+++ b/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
@@ -2,26 +2,12 @@ import { expect } from '../../../setup'
 
 /* External Imports */
 import { ethers } from '@nomiclabs/buidler'
-import { Signer, ContractFactory, Contract, BigNumber } from 'ethers'
-import { smockit, MockContract } from '@eth-optimism/smock'
+import { Signer, Contract } from 'ethers'
 
 /* Internal Imports */
 import {
   makeAddressManager,
-  setProxyTarget,
-  NON_NULL_BYTES32,
-  ZERO_ADDRESS,
-  NON_ZERO_ADDRESS,
-  NULL_BYTES32,
-  DUMMY_BATCH_HEADERS,
-  DUMMY_BATCH_PROOFS,
-  TrieTestGenerator,
-  toHexString,
-  getNextBlockNumber,
-  remove0x,
 } from '../../../helpers'
-import { getContractInterface } from '../../../../src'
-import { keccak256 } from 'ethers/lib/utils'
 
 describe('mockOVM_BondManager', () => {
     let sequencer: Signer

--- a/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
+++ b/test/contracts/mockOVM/verification/mockOVM_BondManager.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from '../../../setup'
+
+/* External Imports */
+import { ethers } from '@nomiclabs/buidler'
+import { Signer, ContractFactory, Contract, BigNumber } from 'ethers'
+import { smockit, MockContract } from '@eth-optimism/smock'
+
+/* Internal Imports */
+import {
+  makeAddressManager,
+  setProxyTarget,
+  NON_NULL_BYTES32,
+  ZERO_ADDRESS,
+  NON_ZERO_ADDRESS,
+  NULL_BYTES32,
+  DUMMY_BATCH_HEADERS,
+  DUMMY_BATCH_PROOFS,
+  TrieTestGenerator,
+  toHexString,
+  getNextBlockNumber,
+  remove0x,
+} from '../../../helpers'
+import { getContractInterface } from '../../../../src'
+import { keccak256 } from 'ethers/lib/utils'
+
+describe('mockOVM_BondManager', () => {
+    let sequencer: Signer
+    let nonSequencer: Signer
+    before(async () => {
+        ;[sequencer, nonSequencer] = await ethers.getSigners()
+    })
+
+  let AddressManager: Contract
+  before(async () => {
+    AddressManager = await makeAddressManager()
+  })
+
+  let mockOVM_BondManager: Contract
+  before(async () => {
+    mockOVM_BondManager = await (
+      await ethers.getContractFactory('mockOVM_BondManager')
+    ).deploy(
+        AddressManager.address
+    )
+   
+    AddressManager.setAddress(
+        'OVM_Sequencer',
+        await sequencer.getAddress()
+    )
+  })
+
+  describe('isCollateralized', () => {
+      it('should return true for OVM_Sequencer', async () => {
+          expect(
+              await mockOVM_BondManager.isCollateralized(await sequencer.getAddress())
+          ).to.equal(true)
+      })
+
+      it('should return false for non-sequencer', async () => {
+        expect(
+            await mockOVM_BondManager.isCollateralized(await nonSequencer.getAddress())
+        ).to.equal(false)
+      })
+  })
+})


### PR DESCRIPTION
## Description
Previously our `mockOVM_BondManager` contract used for testing returned true for `isCollateralized` with any address.  This PR updates that to only return true for whatever the `OVM_Sequencer` address is set to resolve.

## Metadata
### Fixes
- Fixes https://github.com/ethereum-optimism/roadmap/issues/253

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
