### PR TITLE
ctc: disable appendQueueBatch

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -266,6 +266,9 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         override
         public
     {
+        // Disable `appendQueueBatch` for minnet
+        revert("Cannot appendQueueBatch.");
+
         _numQueuedTransactions = Math.min(_numQueuedTransactions, getNumPendingQueueElements());
         require(
             _numQueuedTransactions > 0,

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -267,7 +267,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         public
     {
         // Disable `appendQueueBatch` for minnet
-        revert("Cannot appendQueueBatch.");
+        revert("appendQueueBatch is currently disabled.");
 
         _numQueuedTransactions = Math.min(_numQueuedTransactions, getNumPendingQueueElements());
         require(

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -414,7 +414,7 @@ describe('OVM_CanonicalTransactionChain', () => {
     })
   })
 
-  describe('appendSequencerBatch disabled', () => {
+  describe('appendQueueBatch disabled', () => {
     it('should revert', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(0)

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -418,7 +418,7 @@ describe('OVM_CanonicalTransactionChain', () => {
     it('should revert', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(0)
-      ).to.be.revertedWith('Cannot appendQueueBatch.')
+      ).to.be.revertedWith('appendQueueBatch is currently disabled.')
     })
   })
 
@@ -508,7 +508,7 @@ describe('OVM_CanonicalTransactionChain', () => {
   })
 
   describe('verifyTransaction', () => {
-    it.skip('should successfully verify against a valid queue transaction', async () => {
+    it('should successfully verify against a valid queue transaction', async () => {
       const entrypoint = NON_ZERO_ADDRESS
       const gasLimit = 500_000
       const data = '0x' + '12'.repeat(1234)
@@ -520,7 +520,19 @@ describe('OVM_CanonicalTransactionChain', () => {
       const blockNumber = await ethers.provider.getBlockNumber()
       await increaseEthTime(ethers.provider, FORCE_INCLUSION_PERIOD_SECONDS * 2)
 
-      await OVM_CanonicalTransactionChain.appendQueueBatch(1)
+      await appendSequencerBatch(OVM_CanonicalTransactionChain.connect(sequencer), {
+        shouldStartAtBatch: 0,
+        totalElementsToAppend: 1,
+        contexts: [
+          {
+            numSequencedTransactions: 0,
+            numSubsequentQueueTransactions: 1,
+            timestamp,
+            blockNumber,
+          },
+        ],
+        transactions: [],
+      })
 
       expect(
         await OVM_CanonicalTransactionChain.verifyTransaction(

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -414,7 +414,15 @@ describe('OVM_CanonicalTransactionChain', () => {
     })
   })
 
-  describe('appendQueueBatch', () => {
+  describe('appendSequencerBatch disabled', () => {
+    it('should revert', async () => {
+      await expect(
+        OVM_CanonicalTransactionChain.appendQueueBatch(0)
+      ).to.be.revertedWith('Cannot appendQueueBatch.')
+    })
+  })
+
+  describe.skip('appendQueueBatch', () => {
     it('should revert if trying to append zero transactions', async () => {
       await expect(
         OVM_CanonicalTransactionChain.appendQueueBatch(0)
@@ -500,7 +508,7 @@ describe('OVM_CanonicalTransactionChain', () => {
   })
 
   describe('verifyTransaction', () => {
-    it('should successfully verify against a valid queue transaction', async () => {
+    it.skip('should successfully verify against a valid queue transaction', async () => {
       const entrypoint = NON_ZERO_ADDRESS
       const gasLimit = 500_000
       const data = '0x' + '12'.repeat(1234)


### PR DESCRIPTION
## Description

Disables `appendQueueBatch` at the contract level with a `revert`. Needs to skip a few tests, adds a test for the newly added revert

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
