### PR TITLE
Separates storage from SCC and CTC

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -6,22 +6,14 @@ pragma experimental ABIEncoderV2;
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 import { Lib_MerkleUtils } from "../../libraries/utils/Lib_MerkleUtils.sol";
+import { Lib_Math } from "../../libraries/utils/Lib_Math.sol";
 
 /* Interface Imports */
 import { iOVM_CanonicalTransactionChain } from "../../iOVM/chain/iOVM_CanonicalTransactionChain.sol";
+import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageContainer.sol";
 
 /* Contract Imports */
 import { OVM_ExecutionManager } from "../execution/OVM_ExecutionManager.sol";
-import { OVM_ChainStorageContainer } from "./OVM_ChainStorageContainer.sol";
-
-library Math {
-    function min(uint x, uint y) internal pure returns (uint z) {
-        if (x < y) {
-            return x;
-        }
-        return y;
-    }
-}
 
 
 /**
@@ -79,10 +71,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         public
         view
         returns (
-            OVM_ChainStorageContainer
+            iOVM_ChainStorageContainer
         )
     {
-        return OVM_ChainStorageContainer(
+        return iOVM_ChainStorageContainer(
             resolve("OVM_ChainStorageContainer:CTC:batches")
         );
     }
@@ -95,10 +87,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         public
         view
         returns (
-            OVM_ChainStorageContainer
+            iOVM_ChainStorageContainer
         )
     {
-        return OVM_ChainStorageContainer(
+        return iOVM_ChainStorageContainer(
             resolve("OVM_ChainStorageContainer:CTC:queue")
         );
     }
@@ -273,7 +265,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         override
         public
     {
-        _numQueuedTransactions = Math.min(_numQueuedTransactions, getNumPendingQueueElements());
+        _numQueuedTransactions = Lib_Math.min(_numQueuedTransactions, getNumPendingQueueElements());
         require(
             _numQueuedTransactions > 0,
             "Must append more than zero transactions."

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -253,7 +253,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             timestampAndBlockNumber
         );
 
-        uint40 queueIndex = uint40(queue().length() / 2);
+        uint256 queueIndex = queue().length() / 2;
         emit TransactionEnqueued(
             msg.sender,
             _target,

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -71,7 +71,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * Public Functions *
      ********************/
 
-
+    /**
+     * Accesses the batch storage container.
+     * @return Reference to the batch storage container.
+     */
     function batches()
         public
         view
@@ -80,10 +83,14 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         )
     {
         return OVM_ChainStorageContainer(
-            resolve("ovm:ctc:chain:batches")
+            resolve("OVM_ChainStorageContainer:CTC:batches")
         );
     }
 
+    /**
+     * Accesses the queue storage container.
+     * @return Reference to the queue storage container.
+     */
     function queue()
         public
         view
@@ -92,7 +99,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         )
     {
         return OVM_ChainStorageContainer(
-            resolve("ovm:ctc:chain:queue")
+            resolve("OVM_ChainStorageContainer:CTC:queue")
         );
     }
 

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -178,7 +178,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function del(
+    function deleteElementsAfterInclusive(
         uint256 _index
     )
         override
@@ -193,7 +193,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function del(
+    function deleteElementsAfterInclusive(
         uint256 _index,
         bytes27 _globalMetadata
     )
@@ -210,7 +210,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function overwritable(
+    function setNextOverwritableIndex(
         uint256 _index
     )
         override

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.7.0;
+
+import { Lib_RingBuffer } from "../../libraries/utils/Lib_RingBuffer.sol";
+
+// TODO: Figure out auth.
+contract OVM_ChainStorageContainer {
+    using Lib_RingBuffer for Lib_RingBuffer.RingBuffer;
+
+    Lib_RingBuffer.RingBuffer buffer;
+
+    function setGlobalMetadata(
+        bytes27 _globalMetadata
+    )
+        public
+    {
+        return buffer.setExtraData(_globalMetadata);
+    }
+
+    function getGlobalMetadata()
+        public
+        view
+        returns (
+            bytes27
+        )
+    {
+        return buffer.getExtraData();
+    }
+    
+    function length()
+        public
+        view
+        returns (
+            uint256
+        )
+    {
+        return uint256(buffer.getLength());
+    }
+
+    function push(
+        bytes32 _object,
+        bytes27 _globalMetadata
+    )
+        public
+    {
+        buffer.push(_object, _globalMetadata);
+    }
+
+    function push2(
+        bytes32 _objectA,
+        bytes32 _objectB
+    )
+        public
+    {
+        buffer.push2(_objectA, _objectB);
+    }
+
+    function get(
+        uint256 _index
+    )
+        public
+        view
+        returns (
+            bytes32
+        )
+    {
+        return buffer.get(uint40(_index));
+    }
+    
+    function del(
+        uint256 _index,
+        bytes27 _globalMetadata
+    )
+        public
+    {
+        buffer.deleteElementsAfterInclusive(
+            uint40(_index),
+            _globalMetadata
+        );
+    }
+
+    function overwrite(
+        uint256 _index
+    )
+        public
+    {
+        buffer.nextOverwritableIndex = _index;
+    }
+}

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.7.0;
 
 /* Library Imports */
 import { Lib_RingBuffer } from "../../libraries/utils/Lib_RingBuffer.sol";
+import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 
 /* Interface Imports */
 import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageContainer.sol";
@@ -9,7 +10,7 @@ import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageCo
 /**
  * @title OVM_ChainStorageContainer
  */
-contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
+contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressResolver {
 
     /*************
      * Libraries *
@@ -22,7 +23,39 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
      * Variables *
      *************/
 
-    Lib_RingBuffer.RingBuffer buffer;
+    string public owner;
+    Lib_RingBuffer.RingBuffer internal buffer;
+
+
+    /***************
+     * Constructor *
+     ***************/
+    
+    /**
+     * @param _libAddressManager Address of the Address Manager.
+     * @param _owner Name of the contract that owns this container (will be resolved later).
+     */
+    constructor(
+        address _libAddressManager,
+        string memory _owner
+    )
+        Lib_AddressResolver(_libAddressManager)
+    {
+        owner = _owner;
+    }
+
+
+    /**********************
+     * Function Modifiers *
+     **********************/
+    
+    modifier onlyOwner() {
+        require(
+            msg.sender == resolve(owner),
+            "OVM_ChainStorageContainer: Function can only be called by the owner."
+        );
+        _;
+    }
 
 
     /********************
@@ -37,6 +70,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         return buffer.setExtraData(_globalMetadata);
     }
@@ -77,6 +111,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.push(_object);
     }
@@ -90,6 +125,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.push(_object, _globalMetadata);
     }
@@ -103,6 +139,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.push2(_objectA, _objectB);
     }
@@ -117,6 +154,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.push2(_objectA, _objectB, _globalMetadata);
     }
@@ -145,6 +183,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.deleteElementsAfterInclusive(
             uint40(_index)
@@ -160,6 +199,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.deleteElementsAfterInclusive(
             uint40(_index),
@@ -175,6 +215,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
     )
         override
         public
+        onlyOwner
     {
         buffer.nextOverwritableIndex = _index;
     }

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -1,22 +1,51 @@
 pragma solidity ^0.7.0;
 
+/* Library Imports */
 import { Lib_RingBuffer } from "../../libraries/utils/Lib_RingBuffer.sol";
 
-// TODO: Figure out auth.
-contract OVM_ChainStorageContainer {
+/* Interface Imports */
+import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageContainer.sol";
+
+/**
+ * @title OVM_ChainStorageContainer
+ */
+contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer {
+
+    /*************
+     * Libraries *
+     *************/
+
     using Lib_RingBuffer for Lib_RingBuffer.RingBuffer;
+
+
+    /*************
+     * Variables *
+     *************/
 
     Lib_RingBuffer.RingBuffer buffer;
 
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function setGlobalMetadata(
         bytes27 _globalMetadata
     )
+        override
         public
     {
         return buffer.setExtraData(_globalMetadata);
     }
 
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function getGlobalMetadata()
+        override
         public
         view
         returns (
@@ -25,8 +54,12 @@ contract OVM_ChainStorageContainer {
     {
         return buffer.getExtraData();
     }
-    
+
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function length()
+        override
         public
         view
         returns (
@@ -36,27 +69,65 @@ contract OVM_ChainStorageContainer {
         return uint256(buffer.getLength());
     }
 
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
+    function push(
+        bytes32 _object
+    )
+        override
+        public
+    {
+        buffer.push(_object);
+    }
+
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function push(
         bytes32 _object,
         bytes27 _globalMetadata
     )
+        override
         public
     {
         buffer.push(_object, _globalMetadata);
     }
 
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function push2(
         bytes32 _objectA,
         bytes32 _objectB
     )
+        override
         public
     {
         buffer.push2(_objectA, _objectB);
     }
 
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
+    function push2(
+        bytes32 _objectA,
+        bytes32 _objectB,
+        bytes27 _globalMetadata
+    )
+        override
+        public
+    {
+        buffer.push2(_objectA, _objectB, _globalMetadata);
+    }
+
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function get(
         uint256 _index
     )
+        override
         public
         view
         returns (
@@ -66,10 +137,28 @@ contract OVM_ChainStorageContainer {
         return buffer.get(uint40(_index));
     }
     
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
+    function del(
+        uint256 _index
+    )
+        override
+        public
+    {
+        buffer.deleteElementsAfterInclusive(
+            uint40(_index)
+        );
+    }
+    
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
     function del(
         uint256 _index,
         bytes27 _globalMetadata
     )
+        override
         public
     {
         buffer.deleteElementsAfterInclusive(
@@ -78,9 +167,13 @@ contract OVM_ChainStorageContainer {
         );
     }
 
-    function overwrite(
+    /**
+     * @inheritdoc iOVM_ChainStorageContainer
+     */
+    function overwritable(
         uint256 _index
     )
+        override
         public
     {
         buffer.nextOverwritableIndex = _index;

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
@@ -12,10 +12,10 @@ import { iOVM_FraudVerifier } from "../../iOVM/verification/iOVM_FraudVerifier.s
 import { iOVM_StateCommitmentChain } from "../../iOVM/chain/iOVM_StateCommitmentChain.sol";
 import { iOVM_CanonicalTransactionChain } from "../../iOVM/chain/iOVM_CanonicalTransactionChain.sol";
 import { iOVM_BondManager } from "../../iOVM/verification/iOVM_BondManager.sol";
-import '@openzeppelin/contracts/math/SafeMath.sol';
+import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageContainer.sol";
 
-/* Contract Imports */
-import { OVM_ChainStorageContainer } from "./OVM_ChainStorageContainer.sol";
+/* External Imports */
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 /**
  * @title OVM_StateCommitmentChain
@@ -61,10 +61,10 @@ contract OVM_StateCommitmentChain is iOVM_StateCommitmentChain, Lib_AddressResol
         public
         view
         returns (
-            OVM_ChainStorageContainer
+            iOVM_ChainStorageContainer
         )
     {
-        return OVM_ChainStorageContainer(
+        return iOVM_ChainStorageContainer(
             resolve("OVM_ChainStorageContainer:SCC:batches")
         );
     }
@@ -375,7 +375,7 @@ contract OVM_StateCommitmentChain is iOVM_StateCommitmentChain, Lib_AddressResol
             "Invalid batch header."
         );
 
-        batches().del(
+        batches().deleteElementsAfterInclusive(
             _batchHeader.batchIndex,
             _makeBatchExtraData(
                 uint40(_batchHeader.prevTotalElements),

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
@@ -61,11 +61,6 @@ interface iOVM_CanonicalTransactionChain {
      ********************/
 
     /**
-     * Initializes this contract.
-     */
-    function init() external;
-
-    /**
      * Retrieves the total number of elements submitted.
      * @return _totalElements Total submitted elements.
      */

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
@@ -1,0 +1,135 @@
+pragma solidity ^0.7.0;
+
+/**
+ * @title iOVM_ChainStorageContainer
+ */
+interface iOVM_ChainStorageContainer {
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    /**
+     * Sets the container's global metadata field. We're using `bytes27` here because we use five
+     * bytes to maintain the length of the underlying data structure, meaning we have an extra
+     * 27 bytes to store arbitrary data.
+     * @param _globalMetadata New global metadata to set.
+     */
+    function setGlobalMetadata(
+        bytes27 _globalMetadata
+    )
+        external;
+
+    /**
+     * Retrieves the container's global metadata field.
+     * @return Container global metadata field.
+     */
+    function getGlobalMetadata()
+        external
+        view
+        returns (
+            bytes27
+        );
+
+    /**
+     * Retrieves the number of objects stored in the container.
+     * @return Number of objects in the container.
+     */
+    function length()
+        external
+        view
+        returns (
+            uint256
+        );
+
+    /**
+     * Pushes an object into the container.
+     * @param _object A 32 byte value to insert into the container.
+     */
+    function push(
+        bytes32 _object
+    )
+        external;
+
+    /**
+     * Pushes an object into the container. Function allows setting the global metadata since
+     * we'll need to touch the "length" storage slot anyway, which also contains the global
+     * metadata (it's an optimization).
+     * @param _object A 32 byte value to insert into the container.
+     * @param _globalMetadata New global metadata for the container.
+     */
+    function push(
+        bytes32 _object,
+        bytes27 _globalMetadata
+    )
+        external;
+
+    /**
+     * Pushes two objects into the container at the same time. A useful optimization.
+     * @param _objectA First 32 byte value to insert into the container.
+     * @param _objectB Second 32 byte value to insert into the container.
+     */
+    function push2(
+        bytes32 _objectA,
+        bytes32 _objectB
+    )
+        external;
+
+    /**
+     * Pushes two objects into the container at the same time. Also allows setting the global
+     * metadata field.
+     * @param _objectA First 32 byte value to insert into the container.
+     * @param _objectB Second 32 byte value to insert into the container.
+     * @param _globalMetadata New global metadata for the container.
+     */
+    function push2(
+        bytes32 _objectA,
+        bytes32 _objectB,
+        bytes27 _globalMetadata
+    )
+        external;
+
+    /**
+     * Retrieves an object from the container.
+     * @param _index Index of the particular object to access.
+     * @return 32 byte object value.
+     */
+    function get(
+        uint256 _index
+    )
+        external
+        view
+        returns (
+            bytes32
+        );
+
+    /**
+     * Removes all objects after and including a given index.
+     * @param _index Object index to delete from.
+     */
+    function del(
+        uint256 _index
+    )
+        external;
+
+    /**
+     * Removes all objects after and including a given index. Also allows setting the global
+     * metadata field.
+     * @param _index Object index to delete from.
+     * @param _globalMetadata New global metadata for the container.
+     */
+    function del(
+        uint256 _index,
+        bytes27 _globalMetadata
+    )
+        external;
+
+    /**
+     * Marks an index as overwritable, meaing the underlying buffer can start to write values over
+     * any objects before and including the given index.
+     */
+    function overwritable(
+        uint256 _index
+    )
+        external;
+}

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
@@ -107,7 +107,7 @@ interface iOVM_ChainStorageContainer {
      * Removes all objects after and including a given index.
      * @param _index Object index to delete from.
      */
-    function del(
+    function deleteElementsAfterInclusive(
         uint256 _index
     )
         external;
@@ -118,7 +118,7 @@ interface iOVM_ChainStorageContainer {
      * @param _index Object index to delete from.
      * @param _globalMetadata New global metadata for the container.
      */
-    function del(
+    function deleteElementsAfterInclusive(
         uint256 _index,
         bytes27 _globalMetadata
     )
@@ -128,7 +128,7 @@ interface iOVM_ChainStorageContainer {
      * Marks an index as overwritable, meaing the underlying buffer can start to write values over
      * any objects before and including the given index.
      */
-    function overwritable(
+    function setNextOverwritableIndex(
         uint256 _index
     )
         external;

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
@@ -27,14 +27,10 @@ interface iOVM_StateCommitmentChain {
         bytes32 _batchRoot
     );
 
+
     /********************
      * Public Functions *
      ********************/
-
-    /**
-     * Initializes this contract.
-     */
-    function init() external;
 
     /**
      * Retrieves the total number of elements submitted.

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_StateCommitmentChain.sol
@@ -115,21 +115,4 @@ interface iOVM_StateCommitmentChain {
         returns (
             bool _inside
         );
-    
-    /**
-     * Sets the last batch index that can be deleted.
-     * @param _stateBatchHeader Proposed batch header that can be deleted.
-     * @param _transaction Transaction to verify.
-     * @param _txChainElement Transaction chain element corresponding to the transaction.
-     * @param _txBatchHeader Header of the batch the transaction was included in.
-     * @param _txInclusionProof Inclusion proof for the provided transaction chain element.
-     */
-    function setLastOverwritableIndex(
-        Lib_OVMCodec.ChainBatchHeader memory _stateBatchHeader,
-        Lib_OVMCodec.Transaction memory _transaction,
-        Lib_OVMCodec.TransactionChainElement memory _txChainElement,
-        Lib_OVMCodec.ChainBatchHeader memory _txBatchHeader,
-        Lib_OVMCodec.ChainInclusionProof memory _txInclusionProof
-    )
-        external;
 }

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_Math.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_Math.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+/**
+ * @title Lib_Math
+ */
+library Lib_Math {
+
+    /**********************
+     * Internal Functions *
+     **********************/
+
+    /**
+     * Calculates the minumum of two numbers.
+     * @param _x First number to compare.
+     * @param _y Second number to compare.
+     * @return Lesser of the two numbers.
+     */
+    function min(
+        uint256 _x,
+        uint256 _y
+    )
+        internal
+        pure
+        returns (
+            uint256
+        )
+    {
+        if (_x < _y) {
+            return _x;
+        }
+
+        return _y;
+    }
+}

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -1,9 +1,5 @@
 pragma solidity ^0.7.0;
 
-interface iRingBufferOverwriter {
-    function canOverwrite(bytes32 _id, uint256 _index) external returns (bool);
-}
-
 library Lib_RingBuffer {
     using Lib_RingBuffer for RingBuffer;
 
@@ -17,12 +13,11 @@ library Lib_RingBuffer {
     }
 
     struct RingBuffer {
-        bytes32 id;
-        iRingBufferOverwriter overwriter;
         bytes32 contextA;
         bytes32 contextB;
         Buffer bufferA;
         Buffer bufferB;
+        uint256 nextOverwritableIndex;
     }
 
     struct RingBufferContext {
@@ -49,26 +44,6 @@ library Lib_RingBuffer {
      **********************/
 
     /**
-     * Utility for initializing a ring buffer object.
-     * @param _self Buffer to access.
-     * @param _initialBufferSize Initial length of both sub-buffers.
-     * @param _overwriter Address of the overwriter contract.
-     */
-    function init(
-        RingBuffer storage _self,
-        uint256 _initialBufferSize,
-        bytes32 _id,
-        iRingBufferOverwriter _overwriter
-    )
-        internal
-    {
-        _self.bufferA.length = _initialBufferSize;
-        _self.bufferB.length = _initialBufferSize;
-        _self.id = _id;
-        _self.overwriter = _overwriter;
-    }
-
-    /**
      * Pushes a single element to the buffer.
      * @param _self Buffer to access.
      * @param _value Value to push to the buffer.
@@ -91,15 +66,7 @@ library Lib_RingBuffer {
 
         // Check if we need to expand the buffer.
         if (ctx.globalIndex - ctx.currResetIndex >= currBuffer.length) {
-            bool canOverwrite;
-            try _self.overwriter.canOverwrite(_self.id, ctx.currResetIndex) returns (bool _canOverwrite) {
-                canOverwrite = _canOverwrite;
-            } catch {
-                // Just in case canOverwrite is broken.
-                canOverwrite = false;
-            }
-
-            if (canOverwrite) {
+            if (ctx.currResetIndex < _self.nextOverwritableIndex) {
                 // We're going to overwrite the inactive buffer.
                 // Bump the buffer index, reset the delete offset, and set our reset indices.
                 ctx.currBufferIndex++;
@@ -296,6 +263,22 @@ library Lib_RingBuffer {
     {
         RingBufferContext memory ctx = _self.getContext();
         return ctx.globalIndex;
+    }
+
+    /**
+     * Changes current global extra data.
+     * @param _self Buffer to access.
+     * @param _extraData New global extra data.
+     */
+    function setExtraData(
+        RingBuffer storage _self,
+        bytes27 _extraData
+    )
+        internal
+    {
+        RingBufferContext memory ctx = _self.getContext();
+        ctx.extraData = _extraData;
+        _self.setContext(ctx);
     }
 
     /**

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -248,6 +248,24 @@ library Lib_RingBuffer {
     }
 
     /**
+     * Deletes all elements after (and including) a given index.
+     * @param _self Buffer to access.
+     * @param _index Index of the element to delete from (inclusive).
+     */
+    function deleteElementsAfterInclusive(
+        RingBuffer storage _self,
+        uint40 _index
+    )
+        internal
+    {
+        RingBufferContext memory ctx = _self.getContext();
+        _self.deleteElementsAfterInclusive(
+            _index,
+            ctx.extraData
+        );
+    }
+
+    /**
      * Retrieves the current global index.
      * @param _self Buffer to access.
      * @return Current global index.

--- a/contracts/test-libraries/utils/TestLib_RingBuffer.sol
+++ b/contracts/test-libraries/utils/TestLib_RingBuffer.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 /* Library Imports */
-import { Lib_RingBuffer, iRingBufferOverwriter } from "../../optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol";
+import { Lib_RingBuffer } from "../../optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol";
 
 /**
  * @title TestLib_RingBuffer
@@ -12,20 +12,6 @@ contract TestLib_RingBuffer {
     using Lib_RingBuffer for Lib_RingBuffer.RingBuffer;
     
     Lib_RingBuffer.RingBuffer internal buf;
-
-    function init(
-        uint256 _initialBufferSize,
-        bytes32 _id,
-        iRingBufferOverwriter _overwriter
-    )
-        public
-    {
-        buf.init(
-            _initialBufferSize,
-            _id,
-            _overwriter
-        );
-    }
 
     function push(
         bytes32 _value,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.0.2-alpha.14",
+  "version": "0.0.2-alpha.15",
   "main": "build/src/index.js",
   "files": [
     "build/**/*.js",

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -102,7 +102,7 @@ export const makeContractDeployConfig = async (
         AddressManager.address,
         config.stateChainConfig.fraudProofWindowSeconds,
         config.stateChainConfig.sequencerPublishWindowSeconds,
-      ]
+      ],
     },
     OVM_DeployerWhitelist: {
       factory: getContractFactory('OVM_DeployerWhitelist'),

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -32,6 +32,7 @@ export interface RollupDeployConfig {
     owner: string | Signer
     allowArbitraryContractDeployment: boolean
   }
+  addressManager?: string
   deployOverrides?: Overrides
   dependencies?: string[]
 }
@@ -169,6 +170,15 @@ export const makeContractDeployConfig = async (
     OVM_ETH: {
       factory: getContractFactory('OVM_ETH'),
       params: [config.ethConfig.initialAmount, 'Ether', 18, 'ETH'],
+    },
+    'OVM_ChainStorageContainer:CTC:batches': {
+      factory: getContractFactory('OVM_ChainStorageContainer'),
+    },
+    'OVM_ChainStorageContainer:CTC:queue': {
+      factory: getContractFactory('OVM_ChainStorageContainer'),
+    },
+    'OVM_ChainStorageContainer:SCC:batches': {
+      factory: getContractFactory('OVM_ChainStorageContainer'),
     },
   }
 }

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -173,12 +173,15 @@ export const makeContractDeployConfig = async (
     },
     'OVM_ChainStorageContainer:CTC:batches': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
+      params: [AddressManager.address, 'OVM_CanonicalTransactionChain'],
     },
     'OVM_ChainStorageContainer:CTC:queue': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
+      params: [AddressManager.address, 'OVM_CanonicalTransactionChain'],
     },
     'OVM_ChainStorageContainer:SCC:batches': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
+      params: [AddressManager.address, 'OVM_StateCommitmentChain'],
     },
   }
 }

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -82,7 +82,7 @@ export const makeContractDeployConfig = async (
         AddressManager.address,
         config.transactionChainConfig.forceInclusionPeriodSeconds,
       ],
-      afterDeploy: async (contracts): Promise<void> => {
+      afterDeploy: async (): Promise<void> => {
         const sequencer = config.transactionChainConfig.sequencer
         const sequencerAddress =
           typeof sequencer === 'string'
@@ -94,7 +94,6 @@ export const makeContractDeployConfig = async (
         )
         await AddressManager.setAddress('OVM_Sequencer', sequencerAddress)
         await AddressManager.setAddress('Sequencer', sequencerAddress)
-        await contracts.OVM_CanonicalTransactionChain.init()
       },
     },
     OVM_StateCommitmentChain: {
@@ -103,10 +102,7 @@ export const makeContractDeployConfig = async (
         AddressManager.address,
         config.stateChainConfig.fraudProofWindowSeconds,
         config.stateChainConfig.sequencerPublishWindowSeconds,
-      ],
-      afterDeploy: async (contracts): Promise<void> => {
-        await contracts.OVM_StateCommitmentChain.init()
-      },
+      ]
     },
     OVM_DeployerWhitelist: {
       factory: getContractFactory('OVM_DeployerWhitelist'),

--- a/src/contract-deployment/deploy.ts
+++ b/src/contract-deployment/deploy.ts
@@ -16,10 +16,23 @@ export interface DeployResult {
 export const deploy = async (
   config: RollupDeployConfig
 ): Promise<DeployResult> => {
-  const AddressManager: Contract = await getContractFactory(
-    'Lib_AddressManager',
-    config.deploymentSigner
-  ).deploy()
+  let AddressManager: Contract
+
+  if (config.addressManager) {
+    console.log(`Connecting to existing address manager.`)
+    AddressManager = getContractFactory(
+      'Lib_AddressManager',
+      config.deploymentSigner
+    ).attach(config.addressManager)
+  } else {
+    console.log(
+      `Address manager wasn't provided, so we're deploying a new one.`
+    )
+    AddressManager = await getContractFactory(
+      'Lib_AddressManager',
+      config.deploymentSigner
+    ).deploy()
+  }
 
   const contractDeployConfig = await makeContractDeployConfig(
     config,

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -211,8 +211,14 @@ describe('OVM_CanonicalTransactionChain', () => {
       FORCE_INCLUSION_PERIOD_SECONDS
     )
 
-    const batches = await Factory__OVM_ChainStorageContainer.deploy()
-    const queue = await Factory__OVM_ChainStorageContainer.deploy()
+    const batches = await Factory__OVM_ChainStorageContainer.deploy(
+      AddressManager.address,
+      'OVM_CanonicalTransactionChain'
+    )
+    const queue = await Factory__OVM_ChainStorageContainer.deploy(
+      AddressManager.address,
+      'OVM_CanonicalTransactionChain'
+    )
 
     await AddressManager.setAddress(
       'OVM_ChainStorageContainer:CTC:batches',
@@ -222,6 +228,11 @@ describe('OVM_CanonicalTransactionChain', () => {
     await AddressManager.setAddress(
       'OVM_ChainStorageContainer:CTC:queue',
       queue.address
+    )
+
+    await AddressManager.setAddress(
+      'OVM_CanonicalTransactionChain',
+      OVM_CanonicalTransactionChain.address
     )
   })
 

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -5,7 +5,7 @@ import { ethers } from '@nomiclabs/buidler'
 import { Signer, ContractFactory, Contract, BigNumber } from 'ethers'
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { smockit, MockContract } from '@eth-optimism/smock'
-import _, { times } from 'lodash'
+import _ from 'lodash'
 
 /* Internal Imports */
 import {
@@ -187,16 +187,20 @@ describe('OVM_CanonicalTransactionChain', () => {
       Mock__OVM_StateCommitmentChain
     )
 
-    Mock__OVM_StateCommitmentChain.smocked.canOverwrite.will.return.with(false)
     Mock__OVM_ExecutionManager.smocked.getMaxTransactionGasLimit.will.return.with(
       MAX_GAS_LIMIT
     )
   })
 
   let Factory__OVM_CanonicalTransactionChain: ContractFactory
+  let Factory__OVM_ChainStorageContainer: ContractFactory
   before(async () => {
     Factory__OVM_CanonicalTransactionChain = await ethers.getContractFactory(
       'OVM_CanonicalTransactionChain'
+    )
+
+    Factory__OVM_ChainStorageContainer = await ethers.getContractFactory(
+      'OVM_ChainStorageContainer'
     )
   })
 
@@ -206,7 +210,19 @@ describe('OVM_CanonicalTransactionChain', () => {
       AddressManager.address,
       FORCE_INCLUSION_PERIOD_SECONDS
     )
-    await OVM_CanonicalTransactionChain.init()
+
+    const batches = await Factory__OVM_ChainStorageContainer.deploy()
+    const queue = await Factory__OVM_ChainStorageContainer.deploy()
+
+    await AddressManager.setAddress(
+      'OVM_ChainStorageContainer:CTC:batches',
+      batches.address
+    )
+
+    await AddressManager.setAddress(
+      'OVM_ChainStorageContainer:CTC:queue',
+      queue.address
+    )
   })
 
   describe('enqueue', () => {

--- a/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
@@ -11,7 +11,6 @@ import {
   setProxyTarget,
   NON_NULL_BYTES32,
   ZERO_ADDRESS,
-  toHexString32,
   getEthTime,
   NULL_BYTES32,
   increaseEthTime,
@@ -81,11 +80,19 @@ describe('OVM_StateCommitmentChain', () => {
       60 * 30 // 30 minute sequencer publish window
     )
 
-    const batches = await Factory__OVM_ChainStorageContainer.deploy()
+    const batches = await Factory__OVM_ChainStorageContainer.deploy(
+      AddressManager.address,
+      'OVM_StateCommitmentChain'
+    )
 
     await AddressManager.setAddress(
       'OVM_ChainStorageContainer:SCC:batches',
       batches.address
+    )
+
+    await AddressManager.setAddress(
+      'OVM_StateCommitmentChain',
+      OVM_StateCommitmentChain.address
     )
   })
 

--- a/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
@@ -62,9 +62,14 @@ describe('OVM_StateCommitmentChain', () => {
   })
 
   let Factory__OVM_StateCommitmentChain: ContractFactory
+  let Factory__OVM_ChainStorageContainer: ContractFactory
   before(async () => {
     Factory__OVM_StateCommitmentChain = await ethers.getContractFactory(
       'OVM_StateCommitmentChain'
+    )
+
+    Factory__OVM_ChainStorageContainer = await ethers.getContractFactory(
+      'OVM_ChainStorageContainer'
     )
   })
 
@@ -75,7 +80,13 @@ describe('OVM_StateCommitmentChain', () => {
       60 * 60 * 24 * 7, // 1 week fraud proof window
       60 * 30 // 30 minute sequencer publish window
     )
-    await OVM_StateCommitmentChain.init()
+
+    const batches = await Factory__OVM_ChainStorageContainer.deploy()
+
+    await AddressManager.setAddress(
+      'OVM_ChainStorageContainer:SCC:batches',
+      batches.address
+    )
   })
 
   describe('appendStateBatch', () => {


### PR DESCRIPTION
## Description
Creates a new contract, `OVM_ChainStorageContainer`, which actually stores the values instead of doing it directly in the SCC and CTC.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
