### PR TITLE
Make gas-too-big transactions fail sooner

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -44,6 +44,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
     uint256 internal forceInclusionPeriodSeconds;
     uint256 internal forceInclusionPeriodBlocks;
+    uint256 internal maxTransactionGasLimit;
     uint256 internal lastOVMTimestamp;
 
 
@@ -54,12 +55,14 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     constructor(
         address _libAddressManager,
         uint256 _forceInclusionPeriodSeconds,
-        uint256 _forceInclusionPeriodBlocks
+        uint256 _forceInclusionPeriodBlocks,
+        uint256 _maxTransactionGasLimit
     )
         Lib_AddressResolver(_libAddressManager)
     {
         forceInclusionPeriodSeconds = _forceInclusionPeriodSeconds;
         forceInclusionPeriodBlocks = _forceInclusionPeriodBlocks;
+        maxTransactionGasLimit = _maxTransactionGasLimit;
     }
 
 
@@ -218,7 +221,12 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         require(
             _data.length <= MAX_ROLLUP_TX_SIZE,
-            "Transaction exceeds maximum rollup transaction data size."
+            "Transaction data size exceeds maximum for rollup transaction."
+        );
+
+        require(
+            _gasLimit <= maxTransactionGasLimit,
+            "Transaction gas limit exceeds maximum for rollup transaction."
         );
 
         require(

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -83,6 +83,7 @@ export const makeContractDeployConfig = async (
         AddressManager.address,
         config.transactionChainConfig.forceInclusionPeriodSeconds,
         config.transactionChainConfig.forceInclusionPeriodBlocks,
+        config.ovmGasMeteringConfig.maxTransactionGasLimit
       ],
       afterDeploy: async (): Promise<void> => {
         const sequencer = config.transactionChainConfig.sequencer

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -213,7 +213,8 @@ describe('OVM_CanonicalTransactionChain', () => {
     OVM_CanonicalTransactionChain = await Factory__OVM_CanonicalTransactionChain.deploy(
       AddressManager.address,
       FORCE_INCLUSION_PERIOD_SECONDS,
-      FORCE_INCLUSION_PERIOD_BLOCKS
+      FORCE_INCLUSION_PERIOD_BLOCKS,
+      MAX_GAS_LIMIT
     )
 
     const batches = await Factory__OVM_ChainStorageContainer.deploy(
@@ -253,7 +254,17 @@ describe('OVM_CanonicalTransactionChain', () => {
       await expect(
         OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data)
       ).to.be.revertedWith(
-        'Transaction exceeds maximum rollup transaction data size.'
+        'Transaction data size exceeds maximum for rollup transaction.'
+      )
+    })
+
+    it('should revert when trying to enqueue a transaction with a higher gasLimit than the max', async () => {
+      const data = '0x1234567890'
+
+      await expect(
+        OVM_CanonicalTransactionChain.enqueue(target, MAX_GAS_LIMIT + 1, data)
+      ).to.be.revertedWith(
+        'Transaction gas limit exceeds maximum for rollup transaction.'
       )
     })
 


### PR DESCRIPTION
## Description
This little PR adds logic for the `OVM_CTC.enqueue` function to block transactions with oversized gas limits.

This is also already being done in the execution manager, but failing at the time of submission provides better UX.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
