### PR TITLE
Revert changes to CTC abi

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -131,7 +131,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     /**
      * @inheritdoc iOVM_CanonicalTransactionChain
      */
-    function getNextPendingQueueIndex()
+    function getNextQueueIndex()
         override
         public
         view
@@ -185,7 +185,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             uint40
         )
     {
-        return getQueueLength() - getNextPendingQueueIndex();
+        return getQueueLength() - getNextQueueIndex();
     }
 
     /**
@@ -296,7 +296,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         );
 
         bytes32[] memory leaves = new bytes32[](_numQueuedTransactions);
-        uint40 nextQueueIndex = getNextPendingQueueIndex();
+        uint40 nextQueueIndex = getNextQueueIndex();
 
         for (uint256 i = 0; i < _numQueuedTransactions; i++) {
             if (msg.sender != resolve("OVM_Sequencer")) {
@@ -385,7 +385,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         uint32 numSequencerTransactions = 0;
         // We will sequentially append leaves which are pointers to the queue.
         // The initial queue index is what is currently in storage.
-        uint40 nextQueueIndex = getNextPendingQueueIndex();
+        uint40 nextQueueIndex = getNextQueueIndex();
 
         BatchContext memory curContext;
 

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
@@ -86,7 +86,7 @@ interface iOVM_CanonicalTransactionChain {
      * Returns the index of the next element to be enqueued.
      * @return Index for the next queue element.
      */
-    function getNextPendingQueueIndex()
+    function getNextQueueIndex()
         external
         view
         returns (


### PR DESCRIPTION
## Description
Small update to change back CTC interface to what is currently deployed for ease of testing.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
