### PR TITLE
Moves gas check to applyTransaction

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -170,14 +170,8 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
             return;
         }
 
-        // We require gas to complete the logic here in run() before/after execution,
-        // But must ensure the full _tx.gasLimit can be given to the ovmCALL (determinism)
-        // This includes 1/64 of the gas getting lost because of EIP-150
+        // Check gas right before the call to get total gas consumed by OVM transaction.
         uint256 gasProvided = gasleft();
-        require(
-            gasProvided >= 10000 + _transaction.gasLimit * 64 / 63,
-            "Not enough gas to execute deterministically"
-        );
 
         // Run the transaction, make sure to meter the gas usage.
         ovmCALL(

--- a/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -321,6 +321,15 @@ contract OVM_StateTransitioner is Lib_AddressResolver, OVM_FraudContributor, iOV
             "Invalid transaction provided."
         );
 
+        // We require gas to complete the logic here in run() before/after execution,
+        // But must ensure the full _tx.gasLimit can be given to the ovmCALL (determinism)
+        // This includes 1/64 of the gas getting lost because of EIP-150 (lost twice--first 
+        // going into EM, then going into the code contract).
+        require(
+            gasleft() >= 100000 + _transaction.gasLimit * 1032 / 1000, // 1032/1000 = 1.032 = (64/63)^2 rounded up
+            "Not enough gas to execute transaction deterministically."
+        );
+
         iOVM_ExecutionManager ovmExecutionManager = iOVM_ExecutionManager(resolve("OVM_ExecutionManager"));
 
         // We call `setExecutionManager` right before `run` (and not earlier) just in case the

--- a/test/contracts/OVM/execution/OVM_ExecutionManager/run.spec.ts
+++ b/test/contracts/OVM/execution/OVM_ExecutionManager/run.spec.ts
@@ -101,25 +101,27 @@ const test_run: TestDefinition = {
         },
       ],
     },
-    {
-      name: 'run with insufficient gas supplied',
-      steps: [
-        {
-          functionName: 'run',
-          suppliedGas: OVM_TX_GAS_LIMIT / 2,
-          functionParams: {
-            timestamp: 0,
-            queueOrigin: 0,
-            entrypoint: '$OVM_CALL_HELPER',
-            origin: ZERO_ADDRESS,
-            msgSender: ZERO_ADDRESS,
-            gasLimit: OVM_TX_GAS_LIMIT,
-            subSteps: [],
-          },
-          expectedRevertValue: 'Not enough gas to execute deterministically',
-        },
-      ],
-    },
+    // This functionality has moved to the OVM_StateTransitioner,
+    // but leaving here for future reference on how to use this feature of the EM TestRunner.
+    // {
+    //   name: 'run with insufficient gas supplied',
+    //   steps: [
+    //     {
+    //       functionName: 'run',
+    //       suppliedGas: OVM_TX_GAS_LIMIT / 2,
+    //       functionParams: {
+    //         timestamp: 0,
+    //         queueOrigin: 0,
+    //         entrypoint: '$OVM_CALL_HELPER',
+    //         origin: ZERO_ADDRESS,
+    //         msgSender: ZERO_ADDRESS,
+    //         gasLimit: OVM_TX_GAS_LIMIT,
+    //         subSteps: [],
+    //       },
+    //       expectedRevertValue: 'Not enough gas to execute deterministically',
+    //     },
+    //   ],
+    // },
   ],
 }
 

--- a/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
+++ b/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
@@ -15,6 +15,7 @@ import {
   setProxyTarget,
   TrieTestGenerator,
   ZERO_ADDRESS,
+  numberToHexString
 } from '../../../helpers'
 import {
   MockContract,
@@ -271,7 +272,36 @@ describe('OVM_StateTransitioner', () => {
   })
 
   describe('applyTransaction', () => {
-    // TODO
+    it('Blocks execution if insufficient gas provided', async () => {
+      const gasLimit = 500_000
+      const transaction = {
+        timestamp: '0x12',
+        blockNumber: '0x34',
+        l1QueueOrigin: '0x00',
+        l1TxOrigin: ZERO_ADDRESS,
+        entrypoint: ZERO_ADDRESS,
+        gasLimit: numberToHexString(gasLimit),
+        data: '0x1234'
+      }
+
+      const transactionHash = ethers.utils.keccak256(
+        ethers.utils.solidityPack(
+          ['uint256', 'uint256', 'uint8', 'address', 'address', 'uint256', 'bytes'],
+          [transaction.timestamp, transaction.blockNumber, transaction.l1QueueOrigin, transaction.l1TxOrigin, transaction.entrypoint, transaction.gasLimit, transaction.data]
+        )
+      )
+
+      OVM_StateTransitioner.smodify.set({
+        phase: 0,
+        transactionHash
+      })
+
+      await expect(
+        OVM_StateTransitioner.applyTransaction(transaction, {gasLimit: 30_000})
+      ).to.be.revertedWith(
+        `Not enough gas to execute transaction deterministically`
+      )
+    })
   })
 
   describe('commitContractState', () => {

--- a/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
+++ b/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
@@ -15,7 +15,7 @@ import {
   setProxyTarget,
   TrieTestGenerator,
   ZERO_ADDRESS,
-  numberToHexString
+  numberToHexString,
 } from '../../../helpers'
 import {
   MockContract,
@@ -281,23 +281,41 @@ describe('OVM_StateTransitioner', () => {
         l1TxOrigin: ZERO_ADDRESS,
         entrypoint: ZERO_ADDRESS,
         gasLimit: numberToHexString(gasLimit),
-        data: '0x1234'
+        data: '0x1234',
       }
 
       const transactionHash = ethers.utils.keccak256(
         ethers.utils.solidityPack(
-          ['uint256', 'uint256', 'uint8', 'address', 'address', 'uint256', 'bytes'],
-          [transaction.timestamp, transaction.blockNumber, transaction.l1QueueOrigin, transaction.l1TxOrigin, transaction.entrypoint, transaction.gasLimit, transaction.data]
+          [
+            'uint256',
+            'uint256',
+            'uint8',
+            'address',
+            'address',
+            'uint256',
+            'bytes',
+          ],
+          [
+            transaction.timestamp,
+            transaction.blockNumber,
+            transaction.l1QueueOrigin,
+            transaction.l1TxOrigin,
+            transaction.entrypoint,
+            transaction.gasLimit,
+            transaction.data,
+          ]
         )
       )
 
       OVM_StateTransitioner.smodify.set({
         phase: 0,
-        transactionHash
+        transactionHash,
       })
 
       await expect(
-        OVM_StateTransitioner.applyTransaction(transaction, {gasLimit: 30_000})
+        OVM_StateTransitioner.applyTransaction(transaction, {
+          gasLimit: 30_000,
+        })
       ).to.be.revertedWith(
         `Not enough gas to execute transaction deterministically`
       )


### PR DESCRIPTION
## Description
Small fix moving the `gasleft()` check during transaction application out of the execution manager and into the State Transitioner.  This was causing a real headache in l2geth; this removes that issue from geth while still treating it properly for all possible L1 code paths.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
