### PR TITLE
Unskip tests that were waiting for an update to smock

### DIFF
--- a/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -161,8 +161,7 @@ describe('OVM_SequencerEntrypoint', () => {
       expect(ovmCALL._calldata).to.equal(expectedEOACalldata)
     })
 
-    // TODO: These tests should pass when smock is updated to >=0.1.0
-    it.skip('should revert if TransactionType is >2', async () => {
+    it('should revert if TransactionType is >2', async () => {
       const calldata = '0x03'
       await expect(
         Helper_PrecompileCaller.callPrecompile(
@@ -172,7 +171,7 @@ describe('OVM_SequencerEntrypoint', () => {
       ).to.be.reverted
     })
 
-    it.skip('should revert if TransactionType is 1', async () => {
+    it('should revert if TransactionType is 1', async () => {
       const calldata = '0x01'
       await expect(
         Helper_PrecompileCaller.callPrecompile(


### PR DESCRIPTION
## Description

I found some tests that were skipped, that can/should be re-activated.

This is a tiny PR, so seemed worth doing now. 