### PR TITLE
Fix Memory Bug in bytes slice util

### DIFF
--- a/contracts/optimistic-ethereum/libraries/utils/Lib_BytesUtils.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_BytesUtils.sol
@@ -148,6 +148,10 @@ library Lib_BytesUtils {
             default {
                 tempBytes := mload(0x40)
 
+                //zero out the 32 bytes slice we are about to return
+                //we need to do it because Solidity does not garbage collect
+                mstore(tempBytes, 0)
+
                 mstore(0x40, add(tempBytes, 0x20))
             }
         }

--- a/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
+++ b/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
@@ -83,7 +83,7 @@ contract TestLib_RLPWriter {
         return Lib_RLPWriter.writeBool(_in);
     }
 
-    function writeAddressWithOtherMemory(
+    function writeAddressWithTaintedMemory(
         address _in
     )
         public

--- a/contracts/test-libraries/utils/TestLib_BytesUtils.sol
+++ b/contracts/test-libraries/utils/TestLib_BytesUtils.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_BytesUtils } from "../../optimistic-ethereum/libraries/utils/Lib_BytesUtils.sol";
+import { TestERC20 } from "../../test-helpers/TestERC20.sol";
 
 /**
  * @title TestLib_BytesUtils
@@ -99,6 +100,22 @@ contract TestLib_BytesUtils {
         return Lib_BytesUtils.equal(
             _bytes,
             _other
+        );
+    }
+
+    function sliceWithTaintedMemory(
+        bytes memory _bytes,
+        uint256 _start,
+        uint256 _length
+    )
+        public
+        returns (bytes memory)
+    {
+        new TestERC20();
+        return Lib_BytesUtils.slice(
+            _bytes,
+            _start,
+            _length
         );
     }
 }

--- a/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
+++ b/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
@@ -45,7 +45,7 @@ describe('Lib_RLPWriter', () => {
       const randomAddress = '0x1234123412341234123412341234123412341234'
       const rlpEncodedRandomAddress =
         '0x941234123412341234123412341234123412341234'
-      const encoded = await Lib_RLPWriter.callStatic.writeAddressWithOtherMemory(
+      const encoded = await Lib_RLPWriter.callStatic.writeAddressWithTaintedMemory(
         randomAddress
       )
       expect(encoded).to.eq(rlpEncodedRandomAddress)

--- a/test/contracts/libraries/utils/Lib_BytesUtils.spec.ts
+++ b/test/contracts/libraries/utils/Lib_BytesUtils.spec.ts
@@ -2,8 +2,31 @@
 import { Lib_BytesUtils_TEST_JSON } from '../../../data'
 import { runJsonTest } from '../../../helpers'
 
+/* External Imports */
+import { ethers } from '@nomiclabs/buidler'
+import { Contract } from 'ethers'
+import { expect } from '../../../setup'
+
 describe('Lib_BytesUtils', () => {
   describe('JSON tests', () => {
     runJsonTest('TestLib_BytesUtils', Lib_BytesUtils_TEST_JSON)
+  })
+
+  describe('Use of library with other memory-modifying operations', () => {
+    let TestLib_BytesUtils: Contract
+    before(async () => {
+      TestLib_BytesUtils = await (
+        await ethers.getContractFactory('TestLib_BytesUtils')
+      ).deploy()
+    })
+
+    it('should allow creation of a contract beforehand and still work', async () => {
+      const slice = await TestLib_BytesUtils.callStatic.sliceWithTaintedMemory(
+        '0x123412341234',
+        0,
+        0
+      )
+      expect(slice).to.eq('0x')
+    })
   })
 })


### PR DESCRIPTION
## Description
Fixes a bug where `Lib_BytesUtils.slice` would out-of-gas if asked for a slice of length `0` and memory was nonzero beyond where `0x40` points.

## Metadata
### Fixes
https://github.com/ethereum-optimism/roadmap/issues/393

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
