### PR TITLE
Add nonReentrant to `relayMessage()`

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_BaseCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_BaseCrossDomainMessenger.sol
@@ -40,9 +40,10 @@ abstract contract OVM_BaseCrossDomainMessenger is iOVM_BaseCrossDomainMessenger,
         address _target,
         bytes memory _message,
         uint32 _gasLimit
-    ) nonReentrant
+    )
         override
         public
+        nonReentrant
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
             _target,

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_BaseCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_BaseCrossDomainMessenger.sol
@@ -43,7 +43,6 @@ abstract contract OVM_BaseCrossDomainMessenger is iOVM_BaseCrossDomainMessenger,
     )
         override
         public
-        nonReentrant
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
             _target,

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
@@ -7,6 +7,7 @@ import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 import { Lib_AddressManager } from "../../libraries/resolver/Lib_AddressManager.sol";
 import { Lib_SecureMerkleTrie } from "../../libraries/trie/Lib_SecureMerkleTrie.sol";
+import { Lib_ReentrancyGuard } from "../../libraries/utils/Lib_ReentrancyGuard.sol";
 
 /* Interface Imports */
 import { iOVM_L1CrossDomainMessenger } from "../../iOVM/bridge/iOVM_L1CrossDomainMessenger.sol";
@@ -18,6 +19,7 @@ import { OVM_BaseCrossDomainMessenger } from "./OVM_BaseCrossDomainMessenger.sol
 
 /**
  * @title OVM_L1CrossDomainMessenger
+ * @dev This contract lives on L1. It sends messages to L2, and relays them from L2
  */
 contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCrossDomainMessenger, Lib_AddressResolver {
 
@@ -81,6 +83,7 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCros
     )
         override
         public
+        nonReentrant
         onlyRelayer()
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
@@ -140,6 +143,7 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCros
     )
         override
         public
+        nonReentrant
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
             _target,

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
@@ -19,7 +19,7 @@ import { OVM_BaseCrossDomainMessenger } from "./OVM_BaseCrossDomainMessenger.sol
 
 /**
  * @title OVM_L1CrossDomainMessenger
- * @dev This contract lives on L1. It sends messages to L2, and relays them from L2
+ * @dev This contract lives on L1. It sends L1->L2 messages into L2, and relays L2->L1 messages from L2 to their target on L1.
  */
 contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCrossDomainMessenger, Lib_AddressResolver {
 

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1CrossDomainMessenger.sol
@@ -143,7 +143,6 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, OVM_BaseCros
     )
         override
         public
-        nonReentrant
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(
             _target,

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L2CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L2CrossDomainMessenger.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
+import { Lib_ReentrancyGuard } from "../../libraries/utils/Lib_ReentrancyGuard.sol";
 
 /* Interface Imports */
 import { iOVM_L2CrossDomainMessenger } from "../../iOVM/bridge/iOVM_L2CrossDomainMessenger.sol";
@@ -17,6 +18,7 @@ import { OVM_BaseCrossDomainMessenger } from "./OVM_BaseCrossDomainMessenger.sol
 /**
  * @title OVM_L2CrossDomainMessenger
  * @dev L2 CONTRACT (COMPILED)
+ * This contract lives on L2. It sends messages to L1, and relays them from L1
  */
 contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, OVM_BaseCrossDomainMessenger, Lib_AddressResolver {
 
@@ -50,6 +52,7 @@ contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, OVM_BaseCros
         uint256 _messageNonce
     )
         override
+        nonReentrant
         public
     {
         require(

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L2CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L2CrossDomainMessenger.sol
@@ -18,7 +18,7 @@ import { OVM_BaseCrossDomainMessenger } from "./OVM_BaseCrossDomainMessenger.sol
 /**
  * @title OVM_L2CrossDomainMessenger
  * @dev L2 CONTRACT (COMPILED)
- * This contract lives on L2. It sends messages to L1, and relays them from L1
+ * This contract lives on L2. It sends messages to L1, and relays them from L1.
  */
 contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, OVM_BaseCrossDomainMessenger, Lib_AddressResolver {
 


### PR DESCRIPTION
## Description

This is a fix to Sam's bug. 

## Questions

> Additionally, @karlfloersch pointed out that another way to address this would be checking that the msg.sender == address(0), because this condition can only be satisfied at the first contract ovmCALLed by run.

## Metadata

### Fixes
- Fixes #105 
- Also https://github.com/ethereum-optimism/roadmap/issues/394 (private issue)

## Contributing Agreement

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
