### PR TITLE
weth: don't emit events

### DIFF
--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_ETH.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_ETH.sol
@@ -42,7 +42,6 @@ contract OVM_ETH is iOVM_ERC20 {
         require(balances[msg.sender] >= _value);
         balances[msg.sender] -= _value;
         balances[_to] += _value;
-        emit Transfer(msg.sender, _to, _value);
         return true;
     }
 
@@ -54,7 +53,6 @@ contract OVM_ETH is iOVM_ERC20 {
         if (allowance < MAX_UINT256) {
             allowed[_from][msg.sender] -= _value;
         }
-        emit Transfer(_from, _to, _value);
         return true;
     }
 
@@ -64,7 +62,6 @@ contract OVM_ETH is iOVM_ERC20 {
 
     function approve(address _spender, uint256 _value) external override returns (bool success) {
         allowed[msg.sender][_spender] = _value;
-        emit Approval(msg.sender, _spender, _value);
         return true;
     }
 


### PR DESCRIPTION
## Description

It was observed that the Wrapped Eth precompile contract emits events for fee transfers. This means an additional event will happen for each transaction. @karlfloersch mentioned that this should be removed and it was a really fast change so here is the PR.

I'm 50/50 on thinking this is a good idea - while layer 1 does not have an event emitted for the fee being taken, I think that it could be easily explainable to developers since it is an erc20 being used. The approach that I take in this PR removes the events completely, which also removes events for non tx fee based erc20 transfers. I feel like there should be events for these kinds of transfers. A way to solve this would be to conditionally emit the events, but I think that is kind of strange because events are nice to be able to recreate the state of the contract without needing to play all of the transactions. This is a long way of saying that I don't think this change should be merged without more discussion

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
