### PR TITLE
ctc: public getters, remove dead variable

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -42,10 +42,9 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * Variables *
      *************/
 
-    uint256 internal forceInclusionPeriodSeconds;
-    uint256 internal forceInclusionPeriodBlocks;
-    uint256 internal maxTransactionGasLimit;
-    uint256 internal lastOVMTimestamp;
+    uint256 public forceInclusionPeriodSeconds;
+    uint256 public forceInclusionPeriodBlocks;
+    uint256 public maxTransactionGasLimit;
 
 
     /***************


### PR DESCRIPTION
## Description

Removes unused `lastOVMTimestamp` and makes the constructor args public variables so that they can be fetched by users when constructing transactions. Also useful for the sequencer to configure its gas limit on L2

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
