### PR TITLE
Add reentry protection to ExecutionManager.run()

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -6,8 +6,6 @@ pragma experimental ABIEncoderV2;
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 import { Lib_EthUtils } from "../../libraries/utils/Lib_EthUtils.sol";
-import { Lib_ReentrancyGuard } from "../../libraries/utils/Lib_ReentrancyGuard.sol";
-
 
 /* Interface Imports */
 import { iOVM_ExecutionManager } from "../../iOVM/execution/iOVM_ExecutionManager.sol";
@@ -22,7 +20,7 @@ import { OVM_DeployerWhitelist } from "../precompiles/OVM_DeployerWhitelist.sol"
 /**
  * @title OVM_ExecutionManager
  */
-contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver, Lib_ReentrancyGuard {
+contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
 
     /********************************
      * External Contract References *

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -145,8 +145,8 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver, Lib
     )
         override
         public
-        nonReentrant
     {
+        require(transactionContext.ovmNUMBER == 0, "Only be callable at the start of a transaction");
         // Store our OVM_StateManager instance (significantly easier than attempting to pass the
         // address around in calldata).
         ovmStateManager = iOVM_StateManager(_ovmStateManager);

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -6,6 +6,8 @@ pragma experimental ABIEncoderV2;
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
 import { Lib_EthUtils } from "../../libraries/utils/Lib_EthUtils.sol";
+import { Lib_ReentrancyGuard } from "../../libraries/utils/Lib_ReentrancyGuard.sol";
+
 
 /* Interface Imports */
 import { iOVM_ExecutionManager } from "../../iOVM/execution/iOVM_ExecutionManager.sol";
@@ -20,7 +22,7 @@ import { OVM_DeployerWhitelist } from "../precompiles/OVM_DeployerWhitelist.sol"
 /**
  * @title OVM_ExecutionManager
  */
-contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
+contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver, Lib_ReentrancyGuard {
 
     /********************************
      * External Contract References *
@@ -143,6 +145,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         override
         public
+        nonReentrant
     {
         // Store our OVM_StateManager instance (significantly easier than attempting to pass the
         // address around in calldata).


### PR DESCRIPTION
## Description

Adds reentrancy protection on `ExecutionManager.run()` by ensuring the `transactionContext` is uninitialized.

## Metadata
### Fixes
https://github.com/ethereum-optimism/roadmap/issues/400

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
