### PR TITLE
Adds `notStatic` modifier to `ovmSETNONCE`

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -445,6 +445,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         override
         public
+        notStatic
     {
         _setAccountNonce(ovmADDRESS(), _nonce);
     }


### PR DESCRIPTION
## Description
Fixes a little bug found by sam where nonces could be updated during an `ovmSTATICCALL`.  This does not pose a security risk because behavior will be consistent, but still worth fixing.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
