### PR TITLE
Lib_RingBuffer.RingBuffer.nextOverwritableIndex

### DIFF
--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -84,7 +84,8 @@ library Lib_RingBuffer {
         // Index to write to is the difference of the global and reset indices.
         uint256 writeHead = ctx.globalIndex - ctx.currResetIndex;
         currBuffer.buf[writeHead] = _value;
-
+        self.nextOverwritableIndex +=1;
+        
         // Bump the global index and insert our extra data, then save the context.
         ctx.globalIndex++;
         ctx.extraData = _extraData;


### PR DESCRIPTION
when caller has pushed one element in this buffer, the nextOverwritableIndex should be inc 1.

## Description

## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
