### PR TITLE
[WIP] Add missing comment

### DIFF
--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
@@ -30,6 +30,7 @@ contract OVM_SequencerEntrypoint {
      * calldata[00:01]: transaction type (0 == EIP 155, 2 == Eth Sign Message)
      * calldata[01:33]: signature "r" parameter
      * calldata[33:65]: signature "s" parameter
+     * calldata[65:66]: signature "v" parameter
      * calldata[66:69]: transaction gas limit
      * calldata[69:72]: transaction gas price
      * calldata[72:75]: transaction nonce


### PR DESCRIPTION
### Fixes

- Fixes this dapp hub issue: https://github.com/ethereum-optimism/roadmap/issues/273

I noticed that the encoding order here (r,s,v) does not match what is used in Lib_ECDSAUtils (v,r,s), is that intentional?

https://github.com/ethereum-optimism/contracts-v2/blob/38fd27028f740d0bb01634e406f46fbaf47a369a/contracts/optimistic-ethereum/libraries/utils/Lib_ECDSAUtils.sol#L25
