### PR TITLE
feat: getters for ctc extradata

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -158,7 +158,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             uint40
         )
     {
-        (, uint40 nextQueueIndex,,) = _getBatchExtraData();
+        (,uint40 nextQueueIndex,,) = _getBatchExtraData();
         return nextQueueIndex;
     }
 
@@ -166,6 +166,36 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * Gets the queue element at a particular index.
      * @param _index Index of the queue element to access.
      * @return _element Queue element at the given index.
+     */
+    function getLastTimestamp()
+        override
+        public
+        view
+        returns (
+            uint40
+        )
+    {
+        (,,uint40 lastTimestamp,) = _getBatchExtraData();
+        return lastTimestamp;
+    }
+
+    /**
+     * @inheritdoc iOVM_CanonicalTransactionChain
+     */
+    function getLastBlockNumber()
+        override
+        public
+        view
+        returns (
+            uint40
+        )
+    {
+        (,,,uint40 lastBlockNumber) = _getBatchExtraData();
+        return lastBlockNumber;
+    }
+
+    /**
+     * @inheritdoc iOVM_CanonicalTransactionChain
      */
     function getQueueElement(
         uint256 _index
@@ -886,7 +916,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
                 _nextContext.blockNumber <= nextQueueElement.blockNumber,
                 "Sequencer transaction blockNumber exceeds that of next queue element."
             );
-        }   
+        }
     }
 
     /**

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -163,9 +163,8 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     }
 
     /**
-     * Gets the queue element at a particular index.
-     * @param _index Index of the queue element to access.
-     * @return _element Queue element at the given index.
+     * Returns the timestamp of the last transaction.
+     * @return Timestamp for the last transaction.
      */
     function getLastTimestamp()
         override
@@ -180,7 +179,8 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     }
 
     /**
-     * @inheritdoc iOVM_CanonicalTransactionChain
+     * Returns the blocknumber of the last transaction.
+     * @return Blocknumber for the last transaction.
      */
     function getLastBlockNumber()
         override
@@ -195,7 +195,9 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     }
 
     /**
-     * @inheritdoc iOVM_CanonicalTransactionChain
+     * Gets the queue element at a particular index.
+     * @param _index Index of the queue element to access.
+     * @return _element Queue element at the given index.
      */
     function getQueueElement(
         uint256 _index

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -10,9 +10,9 @@ import { iOVM_ChainStorageContainer } from "../../iOVM/chain/iOVM_ChainStorageCo
 
 /**
  * @title OVM_ChainStorageContainer
- * @dev The Chain Storage Container provides its owner contract with read, write and delete functionality. 
+ * @dev The Chain Storage Container provides its owner contract with read, write and delete functionality.
  * This provides gas efficiency gains by enabling it to overwrite storage slots which can no longer be used
- * in a fraud proof due to the fraud window having passed, and the associated chain state or 
+ * in a fraud proof due to the fraud window having passed, and the associated chain state or
  * transactions being finalized.
  * Three disctint Chain Storage Containers will be deployed on Layer 1:
  * 1. Stores transaction batches for the Canonical Transaction Chain
@@ -42,7 +42,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /***************
      * Constructor *
      ***************/
-    
+
     /**
      * @param _libAddressManager Address of the Address Manager.
      * @param _owner Name of the contract that owns this container (will be resolved later).
@@ -61,7 +61,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**********************
      * Function Modifiers *
      **********************/
-    
+
     modifier onlyOwner() {
         require(
             msg.sender == resolve(owner),
@@ -187,7 +187,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     {
         return buffer.get(uint40(_index));
     }
-    
+
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
@@ -202,7 +202,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
             uint40(_index)
         );
     }
-    
+
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
@@ -131,6 +131,27 @@ interface iOVM_CanonicalTransactionChain {
         view
         returns (
             Lib_OVMCodec.QueueElement memory _element
+
+    /**
+     * Returns the timestamp of the last transaction.
+     * @return Timestamp for the last transaction.
+     */
+    function getLastTimestamp()
+        external
+        view
+        returns (
+            uint40
+        );
+
+    /**
+     * Returns the blocknumber of the last transaction.
+     * @return Blocknumber for the last transaction.
+     */
+    function getLastBlockNumber()
+        external
+        view
+        returns (
+            uint40
         );
 
     /**

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_CanonicalTransactionChain.sol
@@ -131,6 +131,7 @@ interface iOVM_CanonicalTransactionChain {
         view
         returns (
             Lib_OVMCodec.QueueElement memory _element
+        );
 
     /**
      * Returns the timestamp of the last transaction.


### PR DESCRIPTION
## Description

Adds getters for the Canonical Transaction Chain extradata. These 2 methods could be bundled together into a single method if that is preferable. This is useful information and also helpful for debugging. I could imagine contracts spanning L1 and L2 wanting to be able to know this information. Right now the only way to get this information is through `ChainStorageContainer.getGlobalMetadata` and then deserializing by hand

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
