### PR TITLE
feat/multirelay

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
@@ -55,8 +55,7 @@ contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressRes
         external
         onlyBatchRelayer 
     {
-        // @todo: confirm correct string (this or proxy?)
-        iOVM_L1CrossDomainMessenger messenger = iOVM_L1CrossDomainMessenger(resolve("OVM_L1CrossDomainMessenger"));
+        iOVM_L1CrossDomainMessenger messenger = iOVM_L1CrossDomainMessenger(resolve("Proxy__OVM_L1CrossDomainMessenger"));
         for (uint256 i = 0; i < _messages.length; i++) {
             L2ToL1Message memory message = _messages[i];
             messenger.relayMessage(

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
@@ -18,7 +18,6 @@ import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolve
  *
  * Compiler used: solc
  * Runtime target: EVM
- * Execution environment: Layer 1
  */
 contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressResolver {
 

--- a/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/OVM_L1MultiMessageRelayer.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// @unsupported: ovm
+pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+/* Interface Imports */
+import { iOVM_L1CrossDomainMessenger } from "../../iOVM/bridge/iOVM_L1CrossDomainMessenger.sol";
+import { iOVM_L1MultiMessageRelayer } from "../../iOVM/bridge/iOVM_L1MultiMessageRelayer.sol";
+
+/* Contract Imports */
+import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
+
+
+/**
+ * @title OVM_L1MultiMessageRelayer
+ * @dev The L1 Multi-Message Relayer contract is a gas efficiency optimization which enables the 
+ * relayer to submit multiple messages in a single transaction to be relayed by the L1 Cross Domain
+ * Message Sender.
+ *
+ * Compiler used: solc
+ * Runtime target: EVM
+ * Execution environment: Layer 1
+ */
+contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressResolver {
+
+    /***************
+     * Constructor *
+     ***************/
+    constructor(
+        address _libAddressManager
+    ) 
+        Lib_AddressResolver(_libAddressManager)
+    {}
+
+    /**********************
+     * Function Modifiers *
+     **********************/
+
+    modifier onlyBatchRelayer() {
+        require(
+            msg.sender == resolve("OVM_L2BatchMessageRelayer"),
+            "OVM_L1MultiMessageRelayer: Function can only be called by the OVM_L2BatchMessageRelayer"
+        );
+        _;
+    }
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    /**
+     * @notice Forwards multiple cross domain messages to the L1 Cross Domain Messenger for relaying
+     * @param _messages An array of L2 to L1 messages
+     */
+    function batchRelayMessages(L2ToL1Message[] calldata _messages) 
+        override
+        external
+        onlyBatchRelayer 
+    {
+        // @todo: confirm correct string (this or proxy?)
+        iOVM_L1CrossDomainMessenger messenger = iOVM_L1CrossDomainMessenger(resolve("OVM_L1CrossDomainMessenger"));
+        for (uint256 i = 0; i < _messages.length; i++) {
+            L2ToL1Message memory message = _messages[i];
+            messenger.relayMessage(
+                message.target,
+                message.sender,
+                message.message,
+                message.messageNonce,
+                message.proof
+            );
+        }
+    }
+}

--- a/contracts/optimistic-ethereum/iOVM/bridge/iOVM_L1MultiMessageRelayer.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/iOVM_L1MultiMessageRelayer.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+/* Interface Imports */
+import { iOVM_L1CrossDomainMessenger } from "../../iOVM/bridge/iOVM_L1CrossDomainMessenger.sol";
+interface iOVM_L1MultiMessageRelayer {
+
+    struct L2ToL1Message {
+        address target;
+        address sender;
+        bytes message;
+        uint256 messageNonce;
+        iOVM_L1CrossDomainMessenger.L2MessageInclusionProof proof;
+    }
+
+    function batchRelayMessages(L2ToL1Message[] calldata _messages) external; 
+}

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -110,6 +110,12 @@ export const makeContractDeployConfig = async (
         )
       },
     },
+    OVM_MultiRelay: {
+      factory: getContractFactory('OVM_MultiRelay'),
+      params: [
+        await AddressManager.getAddress('Proxy__OVM_L1CrossDomainMessenger'),
+      ],
+    },
     OVM_CanonicalTransactionChain: {
       factory: getContractFactory('OVM_CanonicalTransactionChain'),
       params: [

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -112,9 +112,7 @@ export const makeContractDeployConfig = async (
     },
     OVM_L1MultiMessageRelayer: {
       factory: getContractFactory('OVM_L1MultiMessageRelayer'),
-      params: [
-        AddressManager.address,
-      ],
+      params: [AddressManager.address],
     },
     OVM_CanonicalTransactionChain: {
       factory: getContractFactory('OVM_CanonicalTransactionChain'),

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -110,7 +110,7 @@ export const makeContractDeployConfig = async (
         )
       },
     },
-    OVM_MultiRelay: {
+    OVM_L1MultiMessageRelayer: {
       factory: getContractFactory('OVM_L1MultiMessageRelayer'),
       params: [
         AddressManager.address,

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -111,9 +111,9 @@ export const makeContractDeployConfig = async (
       },
     },
     OVM_MultiRelay: {
-      factory: getContractFactory('OVM_MultiRelay'),
+      factory: getContractFactory('OVM_L1MultiMessageRelayer'),
       params: [
-        await AddressManager.getAddress('Proxy__OVM_L1CrossDomainMessenger'),
+        AddressManager.address,
       ],
     },
     OVM_CanonicalTransactionChain: {

--- a/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
+++ b/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
@@ -1,0 +1,111 @@
+import { expect } from '../../../setup'
+
+/* External Imports */
+import { ethers } from 'hardhat'
+import { Signer, ContractFactory, Contract } from 'ethers'
+import { smockit, MockContract } from '@eth-optimism/smock'
+
+/* Internal Imports */
+import {
+  makeAddressManager,
+  NON_ZERO_ADDRESS,
+} from '../../../helpers'
+
+describe.only('OVM_L1MultiMessageRelayer', () => {
+  let signer: Signer
+  before(async () => {
+    ;[signer] = await ethers.getSigners()
+  })
+  
+  let AddressManager: Contract
+  let Factory__OVM_L1MultiMessageRelayer: ContractFactory
+  let Mock__OVM_L1CrossDomainMessenger: MockContract
+  let messages: any[]
+  
+  before(async () => {
+    AddressManager = await makeAddressManager()
+
+    Factory__OVM_L1MultiMessageRelayer = await ethers.getContractFactory(
+      'OVM_L1MultiMessageRelayer'
+    )
+    
+    Mock__OVM_L1CrossDomainMessenger = smockit(
+      await ethers.getContractFactory('OVM_L1CrossDomainMessenger')
+    )
+
+    // set the address of the mock contract to target
+    await AddressManager.setAddress(
+      'OVM_L1CrossDomainMessenger',
+      Mock__OVM_L1CrossDomainMessenger.address
+    )
+
+    // create a few dummy messages to relay
+    let m1 = {
+      target: "0x1100000000000000000000000000000000000000",
+      message: "message1",
+      sender: "0x2200000000000000000000000000000000000000",
+      proof: "Please believe me",
+      calldata: "0xaabbccddeeff"
+    }
+    let m2 = {
+      target: "0x1100000000000000000000000000000000000000",
+      message: "message2",
+      sender: "0x2200000000000000000000000000000000000000",
+      proof: "Please believe me",
+      calldata: "0xaabbccddeeff"
+    }
+    let m3 = {
+      target: "0x1100000000000000000000000000000000000000",
+      message: "message3",
+      sender: "0x2200000000000000000000000000000000000000",
+      proof: "Please believe me",
+      calldata: "0xaabbccddeeff"
+    }
+    messages = [m1, m2, m3]
+  }
+)
+
+  let OVM_L1MultiMessageRelayer: Contract
+
+  beforeEach(async () => {
+    OVM_L1MultiMessageRelayer = await Factory__OVM_L1MultiMessageRelayer.deploy(
+      AddressManager.address
+    )
+    
+    // set the address of the OVM_L1MultiMessageRelayer, which the OVM_L1CrossDomainMessenger will
+    // check in its onlyRelayer modifier
+    await AddressManager.setAddress(
+      'OVM_L2MessageRelayer', // This is the string currently used in the AddressManager
+      OVM_L1MultiMessageRelayer.address
+    )
+    // setup the mock return value
+    Mock__OVM_L1CrossDomainMessenger.smocked.relayMessage.will.return()
+  })
+
+  describe('batchRelayMessages', () => {
+
+    it('should revert if called by the wrong account', async () => {
+      // set the wrong address to use for ACL
+      await AddressManager.setAddress(
+        'OVM_BatchRelayer',
+        NON_ZERO_ADDRESS
+      )
+
+      await expect(
+        await OVM_L1MultiMessageRelayer.batchRelayMessages(
+          messages
+        )
+      ).to.be.revertedWith('OVM_L1MultiMessageRelayer: Function can only be called by the OVM_L2BatchMessageRelayer')
+    })
+
+    it('Successfully relay multiple messages', async () => {
+      Mock__OVM_L1CrossDomainMessenger.smocked.relayMessage.will.return()
+      await OVM_L1MultiMessageRelayer.batchRelayMessages(
+        messages
+      )
+      await expect(
+        Mock__OVM_L1CrossDomainMessenger.smocked.relayMessage.calls.length
+      ).to.deep.equal(messages.length)
+    })
+  })
+})

--- a/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
+++ b/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../helpers'
 import { sign } from 'crypto'
 
-describe.only('OVM_L1MultiMessageRelayer', () => {
+describe('OVM_L1MultiMessageRelayer', () => {
   let signer: Signer
   before(async () => {
     ;[signer] = await ethers.getSigners()

--- a/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
+++ b/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
@@ -67,7 +67,6 @@ describe.only('OVM_L1MultiMessageRelayer', () => {
       sender: "0x2200000000000000000000000000000000000000",
       messageNonce: 1,
       proof: dummyProof,
-      calldata: "0xaabbccddeeff"
     }
     let m2 = {
       target: "0x1100000000000000000000000000000000000000",
@@ -75,7 +74,6 @@ describe.only('OVM_L1MultiMessageRelayer', () => {
       sender: "0x2200000000000000000000000000000000000000",
       messageNonce: 2,
       proof: dummyProof,
-      calldata: "0xaabbccddeeff"
     }
     let m3 = {
       target: "0x1100000000000000000000000000000000000000",
@@ -83,7 +81,6 @@ describe.only('OVM_L1MultiMessageRelayer', () => {
       sender: "0x2200000000000000000000000000000000000000",
       messageNonce: 2,
       proof: dummyProof,
-      calldata: "0xaabbccddeeff"
     }
     messages = [m1, m2, m3]
   }

--- a/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
+++ b/test/contracts/OVM/bridge/OVM_L1MultiMessageRelayer.ts
@@ -12,7 +12,7 @@ import {
   NON_NULL_BYTES32,
   DUMMY_BATCH_HEADERS,
   DUMMY_BATCH_PROOFS,
-  toHexString
+  toHexString,
 } from '../../../helpers'
 import { sign } from 'crypto'
 
@@ -21,14 +21,13 @@ describe('OVM_L1MultiMessageRelayer', () => {
   before(async () => {
     ;[signer] = await ethers.getSigners()
   })
-  
+
   let AddressManager: Contract
   let Factory__OVM_L1MultiMessageRelayer: ContractFactory
   let Mock__OVM_L1CrossDomainMessenger: MockContract
   let messages: any[]
-  
-  before(async () => {
 
+  before(async () => {
     AddressManager = await makeAddressManager()
 
     Factory__OVM_L1MultiMessageRelayer = await ethers.getContractFactory(
@@ -56,35 +55,34 @@ describe('OVM_L1MultiMessageRelayer', () => {
       stateRoot: NON_NULL_BYTES32,
       stateRootBatchHeader: DUMMY_BATCH_HEADERS[0],
       stateRootProof: DUMMY_BATCH_PROOFS[0],
-      stateTrieWitness: toHexString("some bytes"),
-      storageTrieWitness: toHexString("some more bytes")
-    } 
+      stateTrieWitness: toHexString('some bytes'),
+      storageTrieWitness: toHexString('some more bytes'),
+    }
 
     // create a few dummy messages to relay
     let m1 = {
-      target: "0x1100000000000000000000000000000000000000",
+      target: '0x1100000000000000000000000000000000000000',
       message: NON_NULL_BYTES32,
-      sender: "0x2200000000000000000000000000000000000000",
+      sender: '0x2200000000000000000000000000000000000000',
       messageNonce: 1,
       proof: dummyProof,
     }
     let m2 = {
-      target: "0x1100000000000000000000000000000000000000",
+      target: '0x1100000000000000000000000000000000000000',
       message: NON_NULL_BYTES32,
-      sender: "0x2200000000000000000000000000000000000000",
+      sender: '0x2200000000000000000000000000000000000000',
       messageNonce: 2,
       proof: dummyProof,
     }
     let m3 = {
-      target: "0x1100000000000000000000000000000000000000",
+      target: '0x1100000000000000000000000000000000000000',
       message: NON_NULL_BYTES32,
-      sender: "0x2200000000000000000000000000000000000000",
+      sender: '0x2200000000000000000000000000000000000000',
       messageNonce: 2,
       proof: dummyProof,
     }
     messages = [m1, m2, m3]
-  }
-)
+  })
 
   let OVM_L1MultiMessageRelayer: Contract
 
@@ -105,14 +103,11 @@ describe('OVM_L1MultiMessageRelayer', () => {
 
   describe('batchRelayMessages', () => {
     it('Successfully relay multiple messages', async () => {
-      await OVM_L1MultiMessageRelayer.batchRelayMessages(
-        messages
-      )
+      await OVM_L1MultiMessageRelayer.batchRelayMessages(messages)
       await expect(
         Mock__OVM_L1CrossDomainMessenger.smocked.relayMessage.calls.length
       ).to.deep.equal(messages.length)
     })
-
 
     it('should revert if called by the wrong account', async () => {
       // set the wrong address to use for ACL
@@ -122,10 +117,10 @@ describe('OVM_L1MultiMessageRelayer', () => {
       )
 
       await expect(
-        OVM_L1MultiMessageRelayer.batchRelayMessages(
-          messages
-        )
-      ).to.be.revertedWith('OVM_L1MultiMessageRelayer: Function can only be called by the OVM_L2BatchMessageRelayer')
+        OVM_L1MultiMessageRelayer.batchRelayMessages(messages)
+      ).to.be.revertedWith(
+        'OVM_L1MultiMessageRelayer: Function can only be called by the OVM_L2BatchMessageRelayer'
+      )
     })
   })
 })


### PR DESCRIPTION
## Description

Adds a `MultiRelay` contract that can be set as `OVM_L2MessageRelayer` in the address manager that can call `relayMessage()` many times. This will greatly reduce the number of transactions that need to be sent when relaying L2 to L1 messages.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
