### PR TITLE
Add GenericCrossDomainMessenger (mock) for L1<>L2 testing

### DIFF
--- a/contracts/optimistic-ethereum/mockOVM/bridge/mockOVM_GenericCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/mockOVM/bridge/mockOVM_GenericCrossDomainMessenger.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @title mockOVM_GenericCrossDomainMessenger
+ * @dev An experimental alternative mock for local testing.
+ */
+contract mockOVM_GenericCrossDomainMessenger {
+    address public xDomainMessageSender;
+
+    event SentMessage(
+        address _sender,
+        address _target,
+        bytes _message,
+        uint256 _gasLimit
+    );
+
+    function sendMessage(
+        address _target,
+        bytes memory _message,
+        uint32 _gasLimit
+    )
+        public
+    {
+        emit SentMessage(
+            msg.sender,
+            _target,
+            _message,
+            _gasLimit
+        );
+    }
+
+    function relayMessage(
+        address _sender,
+        address _target,
+        bytes memory _message,
+        uint256 _gasLimit
+    )
+        public
+    {
+        xDomainMessageSender = _sender;
+        _target.call{gas: _gasLimit}(_message);
+        xDomainMessageSender = address(0);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.1.6"
   },
   "devDependencies": {
-    "@eth-optimism/plugins": "0.0.9-alpha.2",
+    "@eth-optimism/plugins": "^0.0.10",
     "@eth-optimism/smock": "0.2.1-alpha.0",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,10 @@
     util.promisify "^1.0.0"
     uuid "^8.3.0"
 
-"@eth-optimism/plugins@0.0.9-alpha.2":
-  version "0.0.9-alpha.2"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/plugins/-/plugins-0.0.9-alpha.2.tgz#4ae897be156d6168efc1594d07fbc3180af735ee"
-  integrity sha512-sKJ7MSb1wSMoH9GaXVsGfZuDGwV1E6uWjjyr8JcFP+HLOkboPolN/XpNsGs1OfvJOSZCa4/Y7MGKECKdZNz38w==
+"@eth-optimism/plugins@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/plugins/-/plugins-0.0.10.tgz#c9cc24b484d64b4adfad8dc21d883b71ba563dde"
+  integrity sha512-OCJStdrTVLVlHHFLP+7WXyKt/dWyzxXzivIuf9V1xAGDavxCg8Y4CFzUq70pf3GpjBw230uFhn8vjq26cBppkA==
   dependencies:
     "@eth-optimism/contracts" "^0.0.2-alpha.14"
     "@eth-optimism/ethereumjs-vm" "^4.2.0-alpha.2"
@@ -90,6 +90,7 @@
     ethereumjs-account "^3.0.0"
     ethjs-common-v1 "npm:ethereumjs-common@1.5.0"
     ethjs-util-v6 "npm:ethereumjs-util@6.2.1"
+    node-fetch "^2.6.1"
 
 "@eth-optimism/smock@0.2.1-alpha.0":
   version "0.2.1-alpha.0"
@@ -6696,7 +6697,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
## Description
Adds a better mock contract for cross domain communications. Necessary so that we can do comms between two unique chains.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
