### PR TITLE
ci: fix for outside contributors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,16 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: webfactory/ssh-agent@v0.4.1
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_READ }}
-
       - name: Build
         run: |
           git clone https://github.com/ethereum-optimism/optimism-integration.git \
-              $HOME/optimism-integration \
-              --recurse-submodules
+              $HOME/optimism-integration
           cd $HOME/optimism-integration
+          sed -i -Ee's#git@github.com:([^/]*)/(.*).git#https://github.com/\1/\2.git#' .gitmodules
+          git submodule init
+          git submodule update
           if [ -z $GITHUB_HEAD_REF ]; then
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi


### PR DESCRIPTION
## Description

Removes the dependency to use an ssh key that is stored as a github secret in CI. This enables outside contributors to run the integration tests.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
