### PR TITLE
Fix package json so the build actually works

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build/**/*.js",
     "build/contracts/*",
     "build/dumps/*json",
-    "build/artifacts/*json"
+    "build/artifacts/**/*.json"
   ],
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Description
We moved over to `hardhat`, which means that the structure of the `artifacts` folder has changed. As a result, our package.json is broken and our artifacts are not being included as part of the `build` folder published to `npm`. We need this update or we can't use any artifacts from our latest contract versions.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
