### PR TITLE
gitflows: easily allow outside contributors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          REMOTE="https://github.com/{{ github.repository }}"
+          REMOTE="https://github.com/${{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
           ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE="https://github.com/{{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |


### PR DESCRIPTION
## Description

This should fix the ability for the CI to properly run during PRs from forks of the repo

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
